### PR TITLE
change program -> programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ supervisord::program { 'myprogram':
 ```ruby
 supervisord::group { 'mygroup':
   priority => 100,
-  program  => ['program1', 'program2', 'program3']
+  programs  => ['program1', 'program2', 'program3']
 }
 ```
 


### PR DESCRIPTION
Changed `program` to `programs` in the README's group config example, which is the correct config option.
