### PR TITLE
properly set minprocs in supervisord.conf

### DIFF
--- a/templates/supervisord_main.erb
+++ b/templates/supervisord_main.erb
@@ -3,7 +3,7 @@ logfile=<%= @log_path %>/<%= @log_file %>
 pidfile=<%= @run_path %>/<%= @pid_file %>
 nodaemon=<%= @nodaemon %>
 minfds=<%= @minfds %>
-minfds=<%= @minprocs %>
+minprocs=<%= @minprocs %>
 umask=<%= @umask %>
 <% if @strip_ansi -%>
 strip_ansi=<%= @strip_ansi %>


### PR DESCRIPTION
Hi.  I noticed minfds was being set twice, the second time with the whatever minprocs is set to.  Thanks for the module!
