### PR TITLE
supervisord::reload should use the $executable parameter set in init.pp

### DIFF
--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -4,7 +4,7 @@
 #
 class supervisord::reload {
 
-  $supervisorctl = '/usr/local/bin/supervisorctl'
+  $supervisorctl = $::supervisord::executable
 
   exec { 'supervisorctl_reread':
     command     => "${supervisorctl} reread",


### PR DESCRIPTION
supervisord::reload used it's own hardcoded path to supervisordctl
