### PR TITLE
group 'root' doesn't exist on various system (such as OpenBSD)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,7 @@ class supervisord::config inherits supervisord {
 
   concat { $supervisord::config_file:
     owner => 'root',
-    group => 'root',
+    group => '0',
     mode  => '0755'
   }
 


### PR DESCRIPTION
therefore, use the more portable construct of using the gid '0'.
