### PR TITLE
Add support for looking up supervisord::program through hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Puppet module to manage the [supervisord](http://supervisord.org/) process control system.
 
-Functions available to configure 
+Functions available to configure
 
 * [programs](http://supervisord.org/configuration.html#program-x-section-settings)
 * [groups](http://supervisord.org/configuration.html#group-x-section-settings)
@@ -31,7 +31,7 @@ class supervisord {
 }
 ```
 
-This will download [setuptool](https://bitbucket.org/pypa/setuptools) and install pip with easy_install. 
+This will download [setuptool](https://bitbucket.org/pypa/setuptools) and install pip with easy_install.
 
 You can pass a specific url with `$setuptools_url = 'url'`
 
@@ -59,6 +59,20 @@ supervisord::program { 'myprogram':
   priority => '100',
   env_var  => 'my_common_envs'
 }
+```
+
+Or you can fully define your programs in hiera:
+
+```yaml
+supervisord::programs:
+  'myprogram':
+    command: 'command --args'
+    autostart: yes
+    autorestart: 'true'
+    environment:
+      HOME: '/home/myuser'
+      PATH: '/bin:/sbin:/usr/bin:/usr/sbin'
+      SECRET: 'mysecret'
 ```
 
 ### Configure a group
@@ -104,4 +118,4 @@ If you submit a pull please try and include tests for the new functionality/fix.
 ### Credits
 
 * Debian init script sourced from the system package.
-* RedHat/Centos init script sourced from https://github.com/Supervisor/initscripts 
+* RedHat/Centos init script sourced from https://github.com/Supervisor/initscripts

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,12 @@ class supervisord(
   $env_var              = undef,
   $directory            = undef,
   $strip_ansi           = false,
-  $nocleanup            = false
+  $nocleanup            = false,
+
+  $eventlisteners       = {},
+  $fcgi_programs        = {},
+  $groups               = {},
+  $programs             = {}
 
 ) inherits supervisord::params {
 
@@ -63,6 +68,11 @@ class supervisord(
   validate_bool($inet_auth)
   validate_bool($strip_ansi)
   validate_bool($nocleanup)
+
+  validate_hash($eventlisteners)
+  validate_hash($fcgi_programs)
+  validate_hash($groups)
+  validate_hash($programs)
 
   validate_absolute_path($config_include)
   validate_absolute_path($log_path)
@@ -89,6 +99,11 @@ class supervisord(
     validate_hash($environment)
     $env_string = hash2csv($environment)
   }
+
+  create_resources('supervisord::eventlistener', $eventlisteners)
+  create_resources('supervisord::fcgi_program', $fcgi_programs)
+  create_resources('supervisord::group', $groups)
+  create_resources('supervisord::program', $programs)
 
   if $install_pip {
     include supervisord::pip


### PR DESCRIPTION
I've explicitly documented the `autostart` and `autorestart` parameters in the Hiera snippet as it may cause some confusion as to what their type really is (and how they're validated).
