### PR TITLE
easy_install is not found even with path set in exec

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -8,16 +8,14 @@ class supervisord::pip inherits supervisord {
     path => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'
   }
 
-  exec { 'install_setuptools':
-    command => "curl ${supervisord::setuptools_url} | python",
-    cwd     => '/tmp',
-    unless  => 'which easy_install',
-    before  => Exec['install_pip']
+  if ! defined(Package['python-setuptools']) {
+    package { 'python-setuptools': }
   }
 
   exec { 'install_pip':
-    command     => 'easy_install pip',
-    unless      => 'which pip'
+    command     => '/usr/bin/easy_install pip',
+    unless      => 'which pip',
+    require     => Package['python-setuptools'],
   }
 
   if $::osfamily == 'RedHat' {


### PR DESCRIPTION
```
Notice: /Stage[main]/Supervisord::Pip/Exec[install_setuptools]/returns: executed successfully
default: Error: Could not find command '/usr/bin/easy_install'
default: Error: /Stage[main]/Supervisord::Pip/Exec[install_pip]/returns: change from notrun to 0 failed: Could not find command '/usr/bin/easy_install'
default: Notice: /Stage[main]/Supervisord::Pip/Exec[pip_provider_name_fix]: Dependency Exec[install_pip] has failures: true
default: Warning: /Stage[main]/Supervisord::Pip/Exec[pip_provider_name_fix]: Skipping because of failed dependencies
```

Related to https://github.com/puphpet/puphpet/issues/816

This is on CentOS 6.4.
