### PR TITLE
Adds RHEL-specific pathing

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,8 @@ class supervisord::params {
   $service_ensure       = 'running'
   $service_name         = 'supervisord'
   $package_name         = 'supervisor'
-  $executable           = '/usr/local/bin/supervisord'
-  $executable_ctl       = '/usr/local/bin/supervisorctl'
+  $executable           = 'supervisord'
+  $executable_ctl       = 'supervisorctl'
 
   $run_path             = '/var/run'
   $pid_file             = 'supervisord.pid'

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -4,9 +4,7 @@
 #
 class supervisord::pip inherits supervisord {
 
-  Exec {
-    path => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'
-  }
+  Exec { path => [ '/usr/bin/', '/usr/local/bin', '/bin', '/usr/local/sbin', '/usr/sbin', '/sbin' ] }
 
   exec { 'install_setuptools':
     command => "curl ${supervisord::setuptools_url} | python",

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -4,6 +4,8 @@
 #
 class supervisord::reload {
 
+  Exec { path => [ '/usr/bin/', '/usr/local/bin' ] }
+
   $supervisorctl = $::supervisord::executable_ctl
 
   exec { 'supervisorctl_reread':

--- a/manifests/supervisorctl.pp
+++ b/manifests/supervisorctl.pp
@@ -8,6 +8,8 @@ define supervisord::supervisorctl(
   $refreshonly   = false
 ) {
 
+  Exec { path => [ '/usr/bin/', '/usr/local/bin' ] }
+
   validate_string($command)
   validate_string($process)
 


### PR DESCRIPTION
`supervisord` and `supervisorctl` are on different paths in RHEL and Debian systems.

The previous setting for path was not working:

```
Exec {
  path => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'
}
```

Was getting this:

```
Notice: /Stage[main]/Supervisord::Pip/Exec[install_setuptools]/returns: executed successfully
default: Error: Could not find command '/usr/bin/easy_install'
default: Error: /Stage[main]/Supervisord::Pip/Exec[install_pip]/returns: change from notrun to 0 failed: Could not find command '/usr/bin/easy_install'
default: Notice: /Stage[main]/Supervisord::Pip/Exec[pip_provider_name_fix]: Dependency Exec[install_pip] has failures: true
default: Warning: /Stage[main]/Supervisord::Pip/Exec[pip_provider_name_fix]: Skipping because of failed dependencies
```

Setting the exec path to contain `/usr/local/bin` fixes issue.

I also separated the paths into array format to make it easier to see easier path.

Related to https://github.com/puphpet/puphpet/issues/816
