### PR TITLE
Parameterize package_name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 class supervisord(
   $package_ensure       = $supervisord::params::package_ensure,
+  $package_name         = $supervisord::params::package_name,
   $package_provider     = $supervisord::params::package_provider,
   $service_ensure       = $supervisord::params::service_ensure,
   $service_name         = $supervisord::params::service_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 # Installs supervisor package (defaults to using pip)
 #
 class supervisord::install inherits supervisord {
-  package { 'supervisor':
+  package { $supervisord::package_name:
     ensure   => $supervisord::package_ensure,
     provider => $supervisord::package_provider
   }


### PR DESCRIPTION
It's already there in params.pp, this PR makes it configurable.

Useful if you've renamed the package in a local/private package provider (apt, pip).
