### PR TITLE
Add class containment using the anchor pattern

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,14 @@ class supervisord(
 
   include supervisord::install, supervisord::config, supervisord::service, supervisord::reload
 
-  Class['supervisord::install'] -> Class['supervisord::config'] ~> Class['supervisord::service']
+  anchor { 'supervisord::begin': }
+  anchor { 'supervisord::end': }
+
+  Anchor['supervisord::begin'] ->
+  Class['supervisord::install'] ->
+  Class['supervisord::config'] ~>
+  Class['supervisord::service'] ->
+  Anchor['supervisord::end']
+
   Class['supervisord::reload'] -> Supervisord::Supervisorctl <| |>
 }


### PR DESCRIPTION
Without this, a wrapper class can't enforce ordering on the module.

http://puppetlabs.com/blog/class-containment-puppet
