### PR TITLE
supervisord::rpcinterface define

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ supervisord::eventlistener { 'mylistener':
 }
 ```
 
+### Configure an rpcinterface
+
+```ruby
+supervisord::rpcinterface { 'laforge':
+  rpcinterface_factory => 'mr.laforge.rpcinterface:make_laforge_rpcinterface'
+}
+```
+
 ### Run supervisorctl Commands
 
 Should you need to run a sequence of command with `supervisorctl` you can use the define type `supervisord::supervisorctl`

--- a/manifests/rpcinterface.pp
+++ b/manifests/rpcinterface.pp
@@ -1,0 +1,29 @@
+# Define: supervisord::rpcinterface
+#
+# This define creates an rpcinterface configuration file
+#
+# Documentation on parameters available at:
+# http://supervisord.org/configuration.html#rpcinterface-x-section-settings
+#
+define supervisord::rpcinterface (
+  $rpcinterface_factory,
+  $ensure                = present,
+  $retries               = undef,
+) {
+
+  include supervisord
+
+  # parameter validation
+  if $retries { validate_re($retries, '^\d+') }
+
+  $conf = "${supervisord::config_include}/rpcinterface_${name}.conf"
+
+  file { $conf:
+    ensure  => $ensure,
+    owner   => 'root',
+    mode    => '0644',
+    content => template('supervisord/conf/rpcinterface.erb'),
+    notify  => Class['supervisord::reload']
+  }
+
+}

--- a/spec/defines/rpcinterface_spec.rb
+++ b/spec/defines/rpcinterface_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'supervisord::rpcinterface', :type  => :define do
+  let(:title) {'foo'}
+  let(:facts) {{ :concat_basedir => '/var/lib/puppet/concat' }}
+  let(:default_params) do
+    { :rpcinterface_factory => 'bar:baz' }
+  end
+
+  context 'default' do
+    let(:params) { default_params }
+    it { should contain_supervisord__rpcinterface('foo') }
+    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/\[rpcinterface:foo\]/) }
+    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/supervisor\.rpcinterface_factory = bar:baz/) }
+    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').without_content(/retries/) }
+  end
+
+  context 'retries' do
+    let(:params) { { :retries => 2 }.merge(default_params) }
+    it { should contain_supervisord__rpcinterface('foo') }
+    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/\[rpcinterface:foo\]/) }
+    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/supervisor\.rpcinterface_factory = bar:baz/) }
+    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/retries = 2/) }
+  end
+
+end

--- a/templates/conf/rpcinterface.erb
+++ b/templates/conf/rpcinterface.erb
@@ -1,0 +1,6 @@
+[rpcinterface:<%= @name %>]
+supervisor.rpcinterface_factory = <%= @rpcinterface_factory %>
+<% if @retries %>
+retries = <%= @retries %>
+<% end -%>
+

--- a/tests/rpcinterface.pp
+++ b/tests/rpcinterface.pp
@@ -1,0 +1,7 @@
+supervisord::rpcinterface {
+  'foo':
+    rpcinterface_factory => 'foo:bar';
+  'bar':
+    rpcinterface_factory => 'baz:bat',
+    retries              => 1,
+}


### PR DESCRIPTION
ok, last one! this one implements the rpcinterface stanza. It will probably have merge conflicts with #28 due to README.md changes, but I can fix that all up if any/all of my PRs are fit to be merged.
