### PR TITLE
Fix supervisorctl command when no process is present

### DIFF
--- a/manifests/supervisorctl.pp
+++ b/manifests/supervisorctl.pp
@@ -17,7 +17,7 @@ define supervisord::supervisorctl(
     $cmd = join([$supervisorctl, $command, $process], ' ')
   }
   else {
-    $cmd = join([$supervisorctl, $command])
+    $cmd = join([$supervisorctl, $command], ' ')
   }
 
   exec { "supervisorctl_command_${name}":

--- a/spec/defines/supervisorctl.rb
+++ b/spec/defines/supervisorctl.rb
@@ -1,13 +1,24 @@
 require 'spec_helper'
 
 describe 'supervisord::supervisorctl', :type => :define do
-  let(:title) {'command_foo'}
   let(:default_params) {{ 
-    :command => 'command',
-    :process => 'foo'
+    :command => 'command'
   }}
-  let(:params) { default_params }
+
   let(:facts) {{ :concat_basedir => '/var/lib/puppet/concat' }}
 
-  it { should contain_supervisord__supervisorctl('command_foo') }
+  context 'without process' do
+    let(:title) {'command'}
+    let(:params) { default_params }
+    it { should contain_supervisord__supervisorctl('command') }
+    it { should contain_exec('supervisorctl_command_command').with_command(/supervisorctl command/) }
+  end
+
+  context 'with process' do
+    let(:title) {'command_foo'}
+    let(:params) { default_params.merge({ :process => 'foo' }) }
+    it { should contain_supervisord__supervisorctl('command_foo') }
+    it { should contain_exec('supervisorctl_command_command_foo').with_command(/supervisorctl command foo/) }
+  end
+
 end


### PR DESCRIPTION
Currently, if you try to create an instance like

``` puppet
supervisord::supervisorctl { 'restart_myapp':
  command => 'command',
}
```

You end up with an `exec` command like `/usr/local/bin/supervisorctlcommand`.

This branch adds the require missing space and increase test coverage over the type.
