### PR TITLE
be puppet-lint friendly

### DIFF
--- a/manifests/eventlistener.pp
+++ b/manifests/eventlistener.pp
@@ -54,7 +54,7 @@ define supervisord::eventlistener(
   if $numprocs_start { validate_re($numprocs_start, '^\d+')}
   if $priority { validate_re($priority, '^\d+') }
   if $autostart { validate_bool($autostart) }
-  if $autorestart { validate_re($autorestart, ['true', 'false', 'unexpected']) }
+  if $autorestart { if !is_bool($autorestart) { validate_re($autorestart, ['true', 'false', 'unexpected']) } }
   if $startsecs { validate_re($startsecs, '^\d+')}
   if $startretries { validate_re($startretries, '^\d+')}
   if $exitcodes { validate_string($exitcodes)}

--- a/manifests/fcgi_program.pp
+++ b/manifests/fcgi_program.pp
@@ -55,7 +55,7 @@ define supervisord::fcgi_program(
   if $numprocs_start { validate_re($numprocs_start, '^\d+')}
   if $priority { validate_re($priority, '^\d+') }
   if $autostart { validate_bool($autostart) }
-  if $autorestart { validate_re($autorestart, ['true', 'false', 'unexpected']) }
+  if $autorestart { if !is_bool($autorestart) { validate_re($autorestart, ['true', 'false', 'unexpected']) } }
   if $startsecs { validate_re($startsecs, '^\d+')}
   if $startretries { validate_re($startretries, '^\d+')}
   if $exitcodes { validate_string($exitcodes)}

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -51,7 +51,7 @@ define supervisord::program(
   if $numprocs_start { validate_re($numprocs_start, '^\d+')}
   if $priority { validate_re($priority, '^\d+') }
   if $autostart { validate_bool($autostart) }
-  if $autorestart { validate_re($autorestart, ['true', 'false', 'unexpected']) }
+  if $autorestart { if !is_bool($autorestart) { validate_re($autorestart, ['true', 'false', 'unexpected']) } }
   if $startsecs { validate_re($startsecs, '^\d+')}
   if $startretries { validate_re($startretries, '^\d+')}
   if $exitcodes { validate_string($exitcodes)}


### PR DESCRIPTION
puppet-lint raises a warning when strings <code>'true'</code> or <code>'false'</code> are used instead of simply <code>true</code> and <code>false</code>.

This patch allows the user to use a <b>boolean</b> for the parameter <code>autorestart</code> (in addition to the strings <code>'true'</code>, <code>'false'</code> and <code>'unexpected'</code>)

No change needed in the templates as <code><%= true %></code>  and <code> <%= 'true' %></code> have the same output.
