### PR TITLE
change 0755 modes to 0644 so conf files are not +x

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,20 +7,20 @@ class supervisord::config inherits supervisord {
   file { $supervisord::config_include:
     ensure => directory,
     owner  => 'root',
-    mode   => '0755'
+    mode   => '0644'
   }
 
   file { $supervisord::log_path:
     ensure => directory,
     owner  => 'root',
-    mode   => '0755'
+    mode   => '0644'
   }
 
   if $supervisord::run_path != '/var/run' {
     file { $supervisord::run_path:
       ensure => directory,
       owner  => 'root',
-      mode   => '0755'
+      mode   => '0644'
     }
   }
 
@@ -28,7 +28,7 @@ class supervisord::config inherits supervisord {
     file { '/etc/init.d/supervisord':
       ensure  => present,
       owner   => 'root',
-      mode    => '0755',
+      mode    => '0644',
       content => template("supervisord/init/${::osfamily}/init.erb")
     }
 
@@ -36,7 +36,7 @@ class supervisord::config inherits supervisord {
       file { $supervisord::init_defaults:
         ensure  => present,
         owner   => 'root',
-        mode    => '0755',
+        mode    => '0644',
         content => template("supervisord/init/${::osfamily}/defaults.erb")
       }
     }
@@ -45,7 +45,7 @@ class supervisord::config inherits supervisord {
   concat { $supervisord::config_file:
     owner => 'root',
     group => '0',
-    mode  => '0755'
+    mode  => '0644'
   }
 
   if $supervisord::unix_socket {

--- a/manifests/eventlistener.pp
+++ b/manifests/eventlistener.pp
@@ -95,7 +95,7 @@ define supervisord::eventlistener(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0755',
+    mode    => '0644',
     content => template('supervisord/conf/eventlistener.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/fcgi_program.pp
+++ b/manifests/fcgi_program.pp
@@ -94,7 +94,7 @@ define supervisord::fcgi_program(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0755',
+    mode    => '0644',
     content => template('supervisord/conf/fcgi_program.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -23,7 +23,7 @@ define supervisord::group (
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0755',
+    mode    => '0644',
     content => template('supervisord/conf/group.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -90,7 +90,7 @@ define supervisord::program(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0755',
+    mode    => '0644',
     content => template('supervisord/conf/program.erb'),
     notify  => Class['supervisord::reload']
   }


### PR DESCRIPTION
I thought it was a bit odd that this module created various *.conf files with a mode of 0755, so I've changed it to 0644 in this PR. Note that this still works with directories (puppet automatically makes them +x if they are +r). 
