### PR TITLE
Change to process name if the numprocs greater than 1

### DIFF
--- a/spec/defines/eventlistener_spec.rb
+++ b/spec/defines/eventlistener_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'supervisord::eventlistener', :type => :define do
   let(:title) {'foo'}
   let(:facts) {{ :concat_basedir => '/var/lib/puppet/concat' }}
-  let(:default_params) do 
+  let(:default_params) do
     {
       :command                 => 'bar',
       :process_name            => '%(process_num)s',
@@ -82,5 +82,16 @@ describe 'supervisord::eventlistener', :type => :define do
   context 'ensure_process_removed' do
     let(:params) { default_params.merge({ :ensure_process => 'removed' }) }
     it { should contain_supervisord__supervisorctl('remove_foo') }
+  end
+
+  context 'change_process_name_on_numprocs_gt_1' do
+    let(:params) do
+    {
+      :command  => 'bar',
+      :numprocs => '2',
+    }
+    end
+    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/numprocs=2/) }
+    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
   end
 end

--- a/spec/defines/fcgi_program_spec.rb
+++ b/spec/defines/fcgi_program_spec.rb
@@ -85,4 +85,16 @@ describe 'supervisord::fcgi_program', :type => :define do
     let(:params) { default_params.merge({ :ensure_process => 'removed' }) }
     it { should contain_supervisord__supervisorctl('remove_foo') }
   end
+
+  context 'change_process_name_on_numprocs_gt_1' do
+    let(:params) do
+    {
+      :numprocs => '2',
+      :command  => 'bar',
+      :socket   => 'tcp://localhost:1000',
+    }
+    end
+    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/numprocs=2/) }
+    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
+  end
 end

--- a/spec/defines/program_spec.rb
+++ b/spec/defines/program_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'supervisord::program', :type => :define do
   let(:title) {'foo'}
   let(:facts) {{ :concat_basedir => '/var/lib/puppet/concat' }}
-  let(:default_params) do 
+  let(:default_params) do
     {
       :command                 => 'bar',
       :process_name            => '%(process_num)s',
@@ -82,5 +82,16 @@ describe 'supervisord::program', :type => :define do
   context 'ensure_process_removed' do
     let(:params) { default_params.merge({ :ensure_process => 'removed' }) }
     it { should contain_supervisord__supervisorctl('remove_foo') }
+  end
+
+  context 'change_process_name_on_numprocs_gt_1' do
+    let(:params) do
+    {
+      :command  => 'bar',
+      :numprocs => '2',
+    }
+    end
+    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/numprocs=2/) }
+    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
   end
 end

--- a/templates/conf/eventlistener.erb
+++ b/templates/conf/eventlistener.erb
@@ -2,6 +2,8 @@
 command=<%= @command %>
 <% if @process_name -%>
 process_name=<%= @process_name %>
+<% elsif @numprocs.to_i > 1 -%>
+process_name=%(program_name)s_%(process_num)02d
 <% end -%>
 <% if @numprocs -%>
 numprocs=<%= @numprocs %>

--- a/templates/conf/fcgi_program.erb
+++ b/templates/conf/fcgi_program.erb
@@ -9,6 +9,8 @@ socket_mode=<%= @socket_mode %>
 <% end -%>
 <% if @process_name -%>
 process_name=<%= @process_name %>
+<% elsif @numprocs.to_i > 1 -%>
+process_name=%(program_name)s_%(process_num)02d
 <% end -%>
 <% if @numprocs -%>
 numprocs=<%= @numprocs %>

--- a/templates/conf/program.erb
+++ b/templates/conf/program.erb
@@ -2,6 +2,8 @@
 command=<%= @command %>
 <% if @process_name -%>
 process_name=<%= @process_name %>
+<% elsif @numprocs.to_i > 1 -%>
+process_name=%(program_name)s_%(process_num)02d
 <% end -%>
 <% if @numprocs -%>
 numprocs=<%= @numprocs %>


### PR DESCRIPTION
According to the [documentation](http://supervisord.org/configuration.html#program-x-section-values) the process name has to be changed if the numprocs value is greater than one.
At the moment this can be achived by defining the process_name manually in the right format.
This enhancement helps to auto set the process_name the right way.

Inspired by the [proletaryo/supervisor module](https://github.com/plathrop/puppet-module-supervisor/blob/de4b8856fa22de923b74acf9d4df49981600d8cf/templates/service.ini.erb#L4)
