### PR TITLE
add param for rhel to enable SCL Py27 in init.d script

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,10 @@ class supervisord(
   $executable_path      = $supervisord::params::executable_path,
   $executable           = $supervisord::params::executable,
   $executable_ctl       = $supervisord::params::executable_ctl,
-
+  
+  $scl_enabled          = $supervisord::params::scl_enabled,
+  $scl_script           = $supervisord::params::scl_script,
+ 
   $log_path             = $supervisord::params::log_path,
   $log_file             = $supervisord::params::log_file,
   $log_level            = $supervisord::params::log_level,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class supervisord(
   
   $scl_enabled          = $supervisord::params::scl_enabled,
   $scl_script           = $supervisord::params::scl_script,
- 
+
   $log_path             = $supervisord::params::log_path,
   $log_file             = $supervisord::params::log_file,
   $log_level            = $supervisord::params::log_level,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,9 @@ class supervisord::params {
   $executable           = "${executable_path}/supervisord"
   $executable_ctl       = "${executable_path}/supervisorctl"
 
+  $scl_enabled          = false
+  $scl_script           = '/opt/rh/python27/enable'
+
   $run_path             = '/var/run'
   $pid_file             = 'supervisord.pid'
   $log_path             = '/var/log/supervisor'

--- a/templates/init/RedHat/init.erb
+++ b/templates/init/RedHat/init.erb
@@ -16,6 +16,10 @@
 # pidfile: <%= @run_path %>/<%= @pid_file %>
 #
 
+<% if @scl_enabled -%>
+[ -e <%= @scl_script %> ] && . <%= @scl_script %>
+<% end -%>
+
 # source function library
 . /etc/rc.d/init.d/functions
 


### PR DESCRIPTION
If you want to run Py27 on Centos 6 you should use RedHat's SCL Python 2.7 Repo.
This provides an Python 2.7 enviroment via RPM and can be activated using `scl enable python27 bash`.

To activate this with puppet, I could set some enviroment variables for my supervisor, but this will run into a chicken-egg problem: supervisord will run in python 2.6 and the embedded system will use 2.7.

My first solution was to set these vars to my global env. This works with `/etc/init.d/supervisord start` **but** `service supervisord start` is using `/bin/sh` wich ignores my bashrc configuration.

**Solution**: add a line to the init.d script, if the param $scl_enabled is set to true your puppet params