### PR TITLE
class inheriting from params class on line 71

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,8 +68,8 @@ class supervisord(
   $groups               = {},
   $programs             = {}
 
-) inherits supervisord::params {
-
+) {
+  include supervisord::params
   validate_bool($install_pip)
   validate_bool($install_init)
   validate_bool($nodaemon)


### PR DESCRIPTION
http://puppet-lint.com/checks/class_inherits_from_params_class/

remote: /tmp/tmp.jyS218xzEJ/supervisord/manifests/init.pp - WARNING: class inheriting from params class on line 71
remote: Error: styleguide violation in supervisord/manifests/init.pp (see above)
remote: Error: 1 styleguide violation(s) found. Commit will be aborted.
remote: Please follow the puppet style guide outlined at:
remote: http://docs.puppetlabs.com/guides/style_guide.html