### PR TITLE
trailing whitespace found on line 18

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class supervisord(
   $executable_path      = $supervisord::params::executable_path,
   $executable           = $supervisord::params::executable,
   $executable_ctl       = $supervisord::params::executable_ctl,
-  
+
   $scl_enabled          = $supervisord::params::scl_enabled,
   $scl_script           = $supervisord::params::scl_script,
 


### PR DESCRIPTION
remote: /tmp/tmp.rBT63IAE0W/supervisord/manifests/init.pp - WARNING: class inheriting from params class on line 71
remote: /tmp/tmp.rBT63IAE0W/supervisord/manifests/init.pp - ERROR: trailing whitespace found on line 18
remote: Error: styleguide violation in supervisord/manifests/init.pp (see above)
remote: Error: 1 styleguide violation(s) found. Commit will be aborted.
remote: Please follow the puppet style guide outlined at:
remote: http://docs.puppetlabs.com/guides/style_guide.html