### PR TITLE
* Add missing slash separator in path

### DIFF
--- a/templates/init/RedHat/defaults.erb
+++ b/templates/init/RedHat/defaults.erb
@@ -5,4 +5,4 @@ set -a
 
 # should probably put both of these options as runtime arguments 
 OPTIONS="-c <%= @config_file %>"
-PIDFILE=<%= @run_path %><%= @pid_file %>
+PIDFILE=<%= @run_path %>/<%= @pid_file %>


### PR DESCRIPTION
I found an issue with the RedHat defaults.erb template.  When it generates the file, it is missing a slash in the PIDFILE path.  If "run_path" is "/var/run" and "pid_file" is "supervisord.pid", then the the line becomes:

PIDFILE=/var/runsupervisord.pid

instead of:

PIDFILE=/var/run/supervisord.pid