### PR TITLE
Use absolute paths to log files as-is.

### DIFF
--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -77,11 +77,13 @@ define supervisord::program(
   # create the correct log variables
   $stdout_logfile_path = $stdout_logfile ? {
         /(NONE|AUTO|syslog)/ => $stdout_logfile,
+        /^\//                => $stdout_logfile,
         default              => "${supervisord::log_path}/${stdout_logfile}",
   }
 
   $stderr_logfile_path = $stderr_logfile ? {
         /(NONE|AUTO|syslog)/ => $stderr_logfile,
+        /^\//                => $stderr_logfile,
         default              => "${supervisord::log_path}/${stderr_logfile}",
   }
 

--- a/spec/defines/program_spec.rb
+++ b/spec/defines/program_spec.rb
@@ -94,4 +94,13 @@ describe 'supervisord::program', :type => :define do
     it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/numprocs=2/) }
     it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
   end
+
+  context 'absolute_log_paths' do
+    let(:params) { default_params.merge({
+      :stdout_logfile => '/path/to/program_foo.log',
+      :stderr_logfile => '/path/to/program_foo.error',
+    }) }
+    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
+    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
+  end
 end


### PR DESCRIPTION
This allows the user to specify a log file location outside of Supervisord's log directory. Relative paths are treated as before.