### PR TITLE
fix inet serverurl path

### DIFF
--- a/templates/supervisord_inet.erb
+++ b/templates/supervisord_inet.erb
@@ -6,7 +6,7 @@ password=<%= @inet_password %>
 <% end -%>
 
 [supervisorctl]
-serverurl=http://<%= @inet_hostname%>:<%= @inet_server_port %>
+serverurl=http://<%= @inet_server_hostname %>:<%= @inet_server_port %>
 <% if @inet_auth -%>
 username=<%= @inet_username %>
 password=<%= @inet_password %>


### PR DESCRIPTION
inet_hostname variable is not defined in the module at all, so I have replaced it with correct one.

There are multiple errors with FUTURE_PARSER=yes during CI, but they are not related to current fix.
https://travis-ci.org/kam1kaze/puppet-supervisord/builds/53780764