### PR TITLE
Add Support for SLES

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ You can pass a specific url with `$setuptools_url = 'url'`
 
 If you want to use your system package manager you can specify that with `supervisord::package_provider`.
 
-You'll also likely need to adjust the `supervisord::service_name` to match that installed by the system package. If you're using Debian or Redhat OS families you'll also want to disable the init scripts with `supervisord::install_init = false`.
+You'll also likely need to adjust the `supervisord::service_name` to match that installed by the system package. If you're using Debian, Redhat or Suse OS families you'll also want to disable the init scripts with `supervisord::install_init = false`.
 
-Note: Only Debian and RedHat families have an init script currently.
+Note: Only Debian, RedHat and Suse families have an init script currently.
 
 ### Configure a program
 
@@ -143,3 +143,4 @@ If you submit a pull please try and include tests for the new functionality/fix.
 
 * Debian init script sourced from the system package.
 * RedHat/Centos init script sourced from https://github.com/Supervisor/initscripts
+* Suse init script modiefied from RedHat/Centos script

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class supervisord(
   $package_ensure       = $supervisord::params::package_ensure,
   $package_name         = $supervisord::params::package_name,
   $package_provider     = $supervisord::params::package_provider,
+  $package_install_options = $supervisord::params::package_install_options,
   $service_ensure       = $supervisord::params::service_ensure,
   $service_name         = $supervisord::params::service_name,
   $install_init         = $supervisord::params::install_init,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,8 @@
 #
 class supervisord::install inherits supervisord {
   package { $supervisord::package_name:
-    ensure   => $supervisord::package_ensure,
-    provider => $supervisord::package_provider
+    ensure          => $supervisord::package_ensure,
+    provider        => $supervisord::package_provider,
+    install_options => $supervisord::package_install_options,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,12 @@ class supervisord::params {
         }
       }
     }
+    'Suse': {
+      $init_defaults     = '/etc/sysconfig/supervisor'
+      $unix_socket_group = 'nobody'
+      $install_init      = true
+      $executable_path   = '/usr/local/bin'
+    }
     'Debian': {
       $init_defaults     = '/etc/default/supervisor'
       $unix_socket_group = 'nogroup'
@@ -34,6 +40,7 @@ class supervisord::params {
   # default supervisord params
   $package_ensure       = 'installed'
   $package_provider     = 'pip'
+  $package_install_options = undef
   $service_ensure       = 'running'
   $service_name         = 'supervisord'
   $package_name         = 'supervisor'

--- a/spec/classes/supervisord_spec.rb
+++ b/spec/classes/supervisord_spec.rb
@@ -41,6 +41,10 @@ describe 'supervisord' do
       let(:facts) {{ :osfamily => 'RedHat', :concat_basedir => concatdir }}
       it { should contain_exec('pip_provider_name_fix') }
     end
+    context 'true and package_install_options not specified' do
+      let(:params) {{ :install_pip => true, :package_install_options => false  }}
+      it { should contain_package('supervisor').with_install_options(false) }
+    end
   end
 
   describe '#env_var' do
@@ -81,6 +85,12 @@ describe 'supervisord' do
         let(:facts) {{ :osfamily => 'RedHat', :concat_basedir => concatdir }}
         it { should contain_file('/etc/init.d/supervisord') }
         it { should contain_file('/etc/sysconfig/supervisord') }
+      end
+
+      context 'with Suse' do
+        let(:facts) {{ :osfamily => 'Suse', :concat_basedir => concatdir }}
+        it { should contain_file('/etc/init.d/supervisord') }
+        it { should contain_file('/etc/sysconfig/supervisor') }
       end
     end
   end

--- a/templates/init/Suse/defaults.erb
+++ b/templates/init/Suse/defaults.erb
@@ -1,0 +1,8 @@
+# this is sourced by the supervisord init script
+# written by jkoppe
+
+set -a 
+
+# should probably put both of these options as runtime arguments 
+OPTIONS="-c <%= @config_file %>"
+PIDFILE=<%= @run_path %>/<%= @pid_file %>

--- a/templates/init/Suse/init.erb
+++ b/templates/init/Suse/init.erb
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# supervisord   This scripts turns supervisord on
+#
+# Author:       Mike McGrath <mmcgrath@redhat.com> (based off yumupdatesd)
+#               Jason Koppe <jkoppe@indeed.com> adjusted to read sysconfig,
+#                   use supervisord tools to start/stop, conditionally wait
+#                   for child processes to shutdown, and startup later
+#
+# chkconfig:    345 83 04
+#
+# description:  supervisor is a process control utility.  It has a web based
+#               xmlrpc interface as well as a few other nifty features.
+# processname:  supervisord
+# config: <%= @config_file %>
+# pidfile: <%= @run_path %>/<%= @pid_file %>
+#
+
+<% if @scl_enabled -%>
+[ -e <%= @scl_script %> ] && . <%= @scl_script %>
+<% end -%>
+
+if [ -f /etc/rc.status ]; then
+    . /etc/rc.status
+    rc_reset
+fi
+
+# source function library
+if [ -f /etc/rc.d/init.d/functions ]; then
+    . /etc/rc.d/init.d/functions
+fi
+
+# source system settings
+[ -e <%= @init_defaults %> ] && . <%= @init_defaults %>
+
+RETVAL=0
+DAEMON=<%= @executable %>
+CTL=<%= @executable_ctl %>
+DESC=supervisord
+PIDFILE=<%= @run_path %>/<%= @pid_file %>
+
+# Tests if executable exists
+if [ ! -x $DAEMON ] ; then
+    echo "Executable not found ${DAEMON}"
+    exit 1
+fi
+
+running_pid()
+{
+    # Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] &&  return 1
+    (cat /proc/$pid/cmdline | tr "\000" "\n"|grep -q $name) || return 1
+    return 0
+}
+
+running()
+{
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    # Obtain the pid and check it against the binary name
+    pid=`cat $PIDFILE`
+    running_pid $pid $DAEMON || return 1
+    return 0
+}
+
+start() {
+    echo -n "Starting $DESC: "
+    if [ -e $PIDFILE ]; then 
+        echo "ALREADY STARTED"
+        return 1
+    else
+        # start supervisord with options from sysconfig (stuff like -c)
+        startproc -p $PIDFILE $DAEMON $OPTIONS
+        # only create the subsyslock if we created the PIDFILE
+        [ -e $PIDFILE ] && touch /var/lock/subsys/supervisord
+        return 0
+    fi
+}
+
+stop() {
+    echo -n "Stopping supervisord: "
+    killproc -p $PIDFILE $DESC 
+    # always remove the subsys.  we might have waited a while, but just remove it at this point.
+    rm -f /var/lock/subsys/supervisord
+    return 0
+}
+
+restart() {
+        stop
+        start
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|force-reload)
+        restart
+        ;;
+    reload)
+        $CTL $OPTIONS reload
+        RETVAL=$?
+        ;;
+    condrestart)
+        [ -f /var/lock/subsys/supervisord ] && restart
+        RETVAL=$?
+        ;;
+    status)
+        echo -n "supervisord is "
+        if running ;  then
+            echo "running"
+        else
+            echo "not running."
+            exit 1
+    fi
+    ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
+        exit 1
+esac
+
+exit $RETVAL


### PR DESCRIPTION
  Developed and tested on SLES 11 SP3, which comes with Python 2.6.X
  However, tested against an additionally installed Python 2.7 installed
  to /usr/local

  To make the pip installer work, I had to use install_options
  to the PIP installer. These are only available with Puppet 4.1
  Therefore the spec tests only contains a test with the options
  set to false, in order to test not to break anything.

  The added init script is adapted from the RedHat one, to make
  it work on SLES.

Let me know if there is something to enhance change etc.