### PR TITLE
Allow overriding of init_defaults template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ You'll also likely need to adjust the `supervisord::service_name` to match that 
 
 Note: Only Debian and RedHat families have an init script currently.
 
+### Override sysconfig template
+
+If `supervisord::install_init` is true (the default), then an init script will be installed, and that script will source the contents of the `templates/init/${::osfamily}/defaults.erb` file.  If you want to override that template, you can set `supervisord::init_template` to the path of an alternative template:
+
+```puppet
+class { 'supervisord':
+  install_pip   => true,
+  init_template => 'my/supervisord/${::osfamily}/defaults.erb'
+}
+```
+
+You almost certainly want to copy and add to the original templates, as they contain important settings.
+
 ### Configure a program
 
 ```puppet

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,7 +40,7 @@ class supervisord::config inherits supervisord {
         ensure  => present,
         owner   => 'root',
         mode    => '0755',
-        content => template("supervisord/init/${::osfamily}/defaults.erb"),
+        content => template($supervisord::init_template),
         notify  => Class['supervisord::service'],
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class supervisord(
   $install_init         = $supervisord::params::install_init,
   $install_pip          = false,
   $init_defaults        = $supervisord::params::init_defaults,
+  $init_template        = $supervisord::params::init_template,
   $setuptools_url       = $supervisord::params::setuptools_url,
   $executable_path      = $supervisord::params::executable_path,
   $executable           = $supervisord::params::executable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,4 +67,5 @@ class supervisord::params {
   $inet_server_hostname = '127.0.0.1'
   $inet_server_port     = '9001'
   $inet_auth            = false
+  $init_template        = "supervisord/init/${::osfamily}/defaults.erb"
 }


### PR DESCRIPTION
This revision allows the `defaults.erb` sysconfig file to be overridden.  It's an alternative to completely disabling the init scripts and replacing them with your own.