### PR TITLE
Params should use main class parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,6 @@ class supervisord(
   $init_defaults        = $supervisord::params::init_defaults,
   $init_template        = $supervisord::params::init_template,
   $setuptools_url       = $supervisord::params::setuptools_url,
-  $executable_path      = $supervisord::params::executable_path,
   $executable           = $supervisord::params::executable,
   $executable_ctl       = $supervisord::params::executable_ctl,
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,8 +37,8 @@ class supervisord::params {
   $service_ensure       = 'running'
   $service_name         = 'supervisord'
   $package_name         = 'supervisor'
-  $executable           = "${executable_path}/supervisord"
-  $executable_ctl       = "${executable_path}/supervisorctl"
+  $executable           = "${::supervisord::executable_path}/supervisord"
+  $executable_ctl       = "${::supervisord::executable_path}/supervisorctl"
 
   $scl_enabled          = false
   $scl_script           = '/opt/rh/python27/enable'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,8 +44,8 @@ class supervisord::params {
   $service_ensure       = 'running'
   $service_name         = 'supervisord'
   $package_name         = 'supervisor'
-  $executable           = "${::supervisord::executable_path}/supervisord"
-  $executable_ctl       = "${::supervisord::executable_path}/supervisorctl"
+  $executable           = "${executable_path}/supervisord"
+  $executable_ctl       = "${executable_path}/supervisorctl"
 
   $scl_enabled          = false
   $scl_script           = '/opt/rh/python27/enable'


### PR DESCRIPTION
If you override the `supervisord::executable_path` parameter in the
main class, it should affect the `supervisord::executable` and
`supervisord::executable_ctl` parameters.

Without this, the value of both executables is calculated locally in
params.pp, without taking into account the main class parameter.

With the patch, the value of `supervisord::executable_path` is fetched
from the main class. If the main class does not override the parameter,
there is a fallback to the params class, resulting in the current behaviour.