### PR TITLE
Expose HTTP server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,65 @@ You'll also likely need to adjust the `supervisord::service_name` to match that 
 
 Note: Only Debian and RedHat families have an init script currently.
 
+### HTTP servers
+
+As of version 3.0a3, Supervisor provides an HTTP server that can listen on a Unix socket, an inet socket, or both.  By default, this module enables the Unix socket HTTP server.  `supervisorctl` issues commands to the HTTP server, and it must be configured to talk to either the Unix socket or the inet socket.  If only one HTTP server is enabled, this module will configure `supervisorctl` to use that HTTP server.  If both HTTP servers are enabled, the Unix socket HTTP server will be used by default.  To use the inet socket instead, set `ctl_socket` to `inet` (its default is `unix`).
+
+#### Configure the Unix HTTP server
+
+The Unix HTTP server is enabled by default.  Its parameters are:
+
+```puppet
+class { 'supervisord':
+  unix_socket       => true,
+  run_path          => '/var/run',
+  unix_socket_mode  => '0700',
+  unix_socket_owner => 'nobody',
+  unix_socket_group => 'nobody',
+  unix_auth         => false,
+  unix_username     => undef,
+  unix_password     => undef,
+}
+```
+
+This results in the following config sections:
+
+```
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+chown=nobody:nobody
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+```
+
+#### Configure the Inet HTTP server
+
+The Inet HTTP server is disabled by default.  Its parameters are:
+
+```puppet
+class { 'supervisord':
+  unix_socket          => false,
+  inet_server          => true,
+  inet_server_hostname => '127.0.0.1',
+  inet_server_port     => '9001',
+  inet_auth            => false,
+  inet_username        => undef,
+  inet_password        => undef,
+}
+```
+
+This results in the following config sections:
+
+```
+[inet_http_server]
+port=127.0.0.1:9001
+
+[supervisorctl]
+serverurl=http://127.0.0.1:9001
+```
+
 ### Configure a program
 
 ```puppet

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,9 +68,17 @@ class supervisord::config inherits supervisord {
     }
   }
 
+  if $supervisord::use_ctl_socket {
+    concat::fragment { 'supervisord_ctl':
+      target  => $supervisord::config_file,
+      content => template('supervisord/supervisord_ctl.erb'),
+      order   => 02
+    }
+  }
+
   concat::fragment { 'supervisord_main':
     target  => $supervisord::config_file,
     content => template('supervisord/supervisord_main.erb'),
-    order   => 02
+    order   => 03
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,13 +58,20 @@ class supervisord::params {
   $config_file          = '/etc/supervisord.conf'
   $setuptools_url       = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
 
+  $ctl_socket           = 'unix'
+
   $unix_socket          = true
   $unix_socket_file     = 'supervisor.sock'
   $unix_socket_mode     = '0700'
   $unix_socket_owner    = 'nobody'
+  $unix_auth            = false
+  $unix_username        = undef
+  $unix_password        = undef
 
   $inet_server          = false
   $inet_server_hostname = '127.0.0.1'
   $inet_server_port     = '9001'
   $inet_auth            = false
+  $inet_username        = undef
+  $inet_password        = undef
 }

--- a/templates/supervisord_ctl.erb
+++ b/templates/supervisord_ctl.erb
@@ -1,0 +1,7 @@
+[supervisorctl]
+serverurl=<%= @ctl_serverurl %>
+<% if @ctl_auth -%>
+username=<%= @ctl_username %>
+password=<%= @ctl_password %>
+<% end -%>
+

--- a/templates/supervisord_inet.erb
+++ b/templates/supervisord_inet.erb
@@ -5,9 +5,3 @@ username=<%= @inet_username %>
 password=<%= @inet_password %>
 <% end -%>
 
-[supervisorctl]
-serverurl=http://<%= @inet_server_hostname %>:<%= @inet_server_port %>
-<% if @inet_auth -%>
-username=<%= @inet_username %>
-password=<%= @inet_password %>
-<% end -%>

--- a/templates/supervisord_unix.erb
+++ b/templates/supervisord_unix.erb
@@ -7,9 +7,3 @@ username=<%= @unix_username %>
 password=<%= @unix_password %>
 <% end -%>
 
-[supervisorctl]
-serverurl=unix://<%= @run_path %>/<%= @unix_socket_file %>
-<% if @unix_auth -%>
-username=<%= @unix_username %>
-password=<%= @unix_password %>
-<% end -%>


### PR DESCRIPTION
The module already handles HTTP server settings, but they are not
documented, and enabling the inet HTTP server results in two
`supervisorctl` config sections being generated.

This revision adds some basic documentation, and provides a way to
manage both Unix and inet HTTP server settings.

**Backward incompatibility warning**

Previously, this module would create two `supervisorctl` config sections if both `unix_socket` and `inet_server` were set to true.  Supervisord allowed this, but the resultant config file is confusing.  This revision will create one or the other, but not both.  Given that the `inet_server` setting was undocumented, this will hopefully not be a problem.