### PR TITLE
Rename 'environment' parameter to avoid conflict with top-level  variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Functions available to configure
 * [eventlisteners](http://supervisord.org/configuration.html#eventlistener-x-section-settings)
 * [rpcinterface](http://supervisord.org/configuration.html#rpcinterface-x-section-settings)
 
+## Deprecation warning
+
+To avoid conflict with puppet master's $environment variable, the *environment* parameter of supervisord::program resource is being renamed *program_environment* and old name will be removed in future version.
+
+#### Examples
+
 ## Examples
 
 ### Configuring supervisord with defaults
@@ -121,9 +127,9 @@ You almost certainly want to copy and add to the original templates, as they con
 
 ```puppet
 supervisord::program { 'myprogram':
-  command     => 'command --args',
-  priority    => '100',
-  environment => {
+  command             => 'command --args',
+  priority            => '100',
+  program_environment => {
     'HOME'   => '/home/myuser',
     'PATH'   => '/bin:/sbin:/usr/bin:/usr/sbin',
     'SECRET' => 'mysecret'
@@ -149,7 +155,7 @@ supervisord::programs:
     command: 'command --args'
     autostart: yes
     autorestart: 'true'
-    environment:
+    program_environment:
       HOME: '/home/myuser'
       PATH: '/bin:/sbin:/usr/bin:/usr/sbin'
       SECRET: 'mysecret'

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ You can pass a specific url with `$setuptools_url = 'url'`
 
 If you want to use your system package manager you can specify that with `supervisord::package_provider`.
 
-You'll also likely need to adjust the `supervisord::service_name` to match that installed by the system package. If you're using Debian or Redhat OS families you'll also want to disable the init scripts with `supervisord::install_init = false`.
+You'll also likely need to adjust the `supervisord::service_name` to match that installed by the system package. If you're using Debian, Redhat or Suse OS families you'll also want to disable the init scripts with `supervisord::install_init = false`.
 
-Note: Only Debian and RedHat families have an init script currently.
+Note: Only Debian, RedHat and Suse families have an init script currently.
 
 ### HTTP servers
 
@@ -215,3 +215,4 @@ If you submit a pull please try and include tests for the new functionality/fix.
 
 * Debian init script sourced from the system package.
 * RedHat/Centos init script sourced from https://github.com/Supervisor/initscripts
+* Suse init script modiefied from RedHat/Centos script

--- a/manifests/eventlistener.pp
+++ b/manifests/eventlistener.pp
@@ -37,6 +37,7 @@ define supervisord::eventlistener(
   $stderr_logfile_backups  = undef,
   $stderr_events_enabled   = undef,
   $environment             = undef,
+  $event_environment       = undef,
   $directory               = undef,
   $umask                   = undef,
   $serverurl               = undef
@@ -88,15 +89,21 @@ define supervisord::eventlistener(
         default              => "${supervisord::log_path}/${stderr_logfile}",
   }
 
+  # Handle deprecated $environment variable
+  $_event_environment = $event_environment ? {
+    undef   => $environment,
+    default => $event_environment
+  }
+
   # convert environment data into a csv
   if $env_var {
     $env_hash = hiera_hash($env_var)
     validate_hash($env_hash)
     $env_string = hash2csv($env_hash)
   }
-  elsif $environment {
-    validate_hash($environment)
-    $env_string = hash2csv($environment)
+  elsif $_event_environment {
+    validate_hash($_event_environment)
+    $env_string = hash2csv($_event_environment)
   }
 
   if $events {

--- a/manifests/fcgi_program.pp
+++ b/manifests/fcgi_program.pp
@@ -39,6 +39,7 @@ define supervisord::fcgi_program(
   $stderr_capture_maxbytes = undef,
   $stderr_events_enabled   = undef,
   $environment             = undef,
+  $program_environment     = undef,
   $directory               = undef,
   $umask                   = undef,
   $serverurl               = undef
@@ -91,15 +92,21 @@ define supervisord::fcgi_program(
         default              => "${supervisord::log_path}/${stderr_logfile}",
   }
 
+  # Handle deprecated $environment variable
+  $_program_environment = $program_environment ? {
+    undef   => $environment,
+    default => $program_environment
+  }
+
   # convert environment data into a csv
   if $env_var {
     $env_hash = hiera_hash($env_var)
     validate_hash($env_hash)
     $env_string = hash2csv($env_hash)
   }
-  elsif $environment {
-    validate_hash($environment)
-    $env_string = hash2csv($environment)
+  elsif $_program_environment {
+    validate_hash($_program_environment)
+    $env_string = hash2csv($_program_environment)
   }
 
   $conf = "${supervisord::config_include}/fcgi-program_${name}.conf"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,7 @@ class supervisord(
   $identifier           = undef,
   $childlogdir          = undef,
   $environment          = undef,
+  $global_environment   = undef,
   $env_var              = undef,
   $directory            = undef,
   $strip_ansi           = false,
@@ -137,14 +138,20 @@ class supervisord(
     validte_string($inet_password)
   }
 
+  # Handle deprecated $environment variable
+  $_global_environment = $global_environment ? {
+    undef   => $environment,
+    default => $global_environment
+  }
+
   if $env_var {
     validate_hash($env_var)
     $env_hash = hiera($env_var)
     $env_string = hash2csv($env_hash)
   }
-  elsif $environment {
-    validate_hash($environment)
-    $env_string = hash2csv($environment)
+  elsif $_global_environment {
+    validate_hash($_global_environment)
+    $env_string = hash2csv($_global_environment)
   }
 
   if $config_dirs {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class supervisord(
   $package_ensure       = $supervisord::params::package_ensure,
   $package_name         = $supervisord::params::package_name,
   $package_provider     = $supervisord::params::package_provider,
+  $package_install_options = $supervisord::params::package_install_options,
   $service_ensure       = $supervisord::params::service_ensure,
   $service_name         = $supervisord::params::service_name,
   $install_init         = $supervisord::params::install_init,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,8 @@
 #
 class supervisord::install inherits supervisord {
   package { $supervisord::package_name:
-    ensure   => $supervisord::package_ensure,
-    provider => $supervisord::package_provider
+    ensure          => $supervisord::package_ensure,
+    provider        => $supervisord::package_provider,
+    install_options => $supervisord::package_install_options,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,12 @@ class supervisord::params {
         }
       }
     }
+    'Suse': {
+      $init_defaults     = '/etc/sysconfig/supervisor'
+      $unix_socket_group = 'nobody'
+      $install_init      = true
+      $executable_path   = '/usr/local/bin'
+    }
     'Debian': {
       $init_defaults     = '/etc/default/supervisor'
       $unix_socket_group = 'nogroup'
@@ -34,6 +40,7 @@ class supervisord::params {
   # default supervisord params
   $package_ensure       = 'installed'
   $package_provider     = 'pip'
+  $package_install_options = undef
   $service_ensure       = 'running'
   $service_name         = 'supervisord'
   $package_name         = 'supervisor'

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -35,6 +35,7 @@ define supervisord::program(
   $stderr_logfile_backups  = undef,
   $stderr_capture_maxbytes = undef,
   $stderr_events_enabled   = undef,
+  $program_environment     = undef,
   $environment             = undef,
   $directory               = undef,
   $umask                   = undef,
@@ -87,15 +88,21 @@ define supervisord::program(
         default              => "${supervisord::log_path}/${stderr_logfile}",
   }
 
+  # Handle deprecated $environment variable
+  $_program_environment = $program_environment ? {
+    undef   => $environment,
+    default => $program_environment
+  }
+
   # convert environment data into a csv
   if $env_var {
     $env_hash = hiera_hash($env_var)
     validate_hash($env_hash)
     $env_string = hash2csv($env_hash)
   }
-  elsif $environment {
-    validate_hash($environment)
-    $env_string = hash2csv($environment)
+  elsif $_program_environment {
+    validate_hash($_program_environment)
+    $env_string = hash2csv($_program_environment)
   }
 
   $conf = "${supervisord::config_include}/program_${name}.conf"

--- a/spec/acceptance/supervisord_spec.rb
+++ b/spec/acceptance/supervisord_spec.rb
@@ -29,10 +29,10 @@ describe 'supervisord::program' do
 
       pp = <<-EOS
         include supervisord
-        supervisord::program { 'test': 
-          command => 'echo', 
-          priority => '100', 
-          environment => { 
+        supervisord::program { 'test':
+          command => 'echo',
+          priority => '100',
+          program_environment => {
             'HOME' => '/root',
             'PATH' => '/bin',
           }
@@ -52,7 +52,7 @@ describe 'supervisord::program' do
       expect(shell(cmd).exit_code).to eq(0)
     end
   end
-end 
+end
 
 describe 'supervisord::fcgi-program' do
   context 'create fcgi-program config' do
@@ -61,10 +61,10 @@ describe 'supervisord::fcgi-program' do
       pp = <<-EOS
         include supervisord
         supervisord::fcgi_program { 'test':
-          socket  => 'tcp://localhost:1000',
-          command => 'echo',
-          priority => '100',
-          environment => {
+          socket              => 'tcp://localhost:1000',
+          command             => 'echo',
+          priority            => '100',
+          program_environment => {
             'HOME' => '/root',
             'PATH' => '/bin',
           }

--- a/spec/classes/supervisord_spec.rb
+++ b/spec/classes/supervisord_spec.rb
@@ -54,12 +54,12 @@ describe 'supervisord' do
     end
   end
 
-  describe '#environment' do
+  describe '#global_environment' do
     context 'default' do
       it { should contain_class('supervisord').without_env_string }
     end
     context 'is specified' do
-      let(:params) {{ :environment => { 'key1' => 'value1', 'key2' => 'value2' } }}
+      let(:params) {{ :global_environment => { 'key1' => 'value1', 'key2' => 'value2' } }}
       it { should contain_concat__fragment('supervisord_main')\
         .with_content(/environment=key1='value1',key2='value2'/) }
     end
@@ -70,7 +70,7 @@ describe 'supervisord' do
       it { should_not contain_file('/etc/init.d/supervisord') }
     end
 
-    context 'false' do 
+    context 'false' do
       it { should_not contain_file('/etc/init.d/supervisord') }
     end
 
@@ -94,7 +94,7 @@ describe 'supervisord' do
       end
     end
   end
-      
+
   describe '#unix_socket' do
     context 'default' do
       it { should contain_concat__fragment('supervisord_unix')}

--- a/spec/classes/supervisord_spec.rb
+++ b/spec/classes/supervisord_spec.rb
@@ -41,6 +41,10 @@ describe 'supervisord' do
       let(:facts) {{ :osfamily => 'RedHat', :concat_basedir => concatdir }}
       it { should contain_exec('pip_provider_name_fix') }
     end
+    context 'true and package_install_options not specified' do
+      let(:params) {{ :install_pip => true, :package_install_options => false  }}
+      it { should contain_package('supervisor').with_install_options(false) }
+    end
   end
 
   describe '#env_var' do
@@ -81,6 +85,12 @@ describe 'supervisord' do
         let(:facts) {{ :osfamily => 'RedHat', :concat_basedir => concatdir }}
         it { should contain_file('/etc/init.d/supervisord') }
         it { should contain_file('/etc/sysconfig/supervisord') }
+      end
+
+      context 'with Suse' do
+        let(:facts) {{ :osfamily => 'Suse', :concat_basedir => concatdir }}
+        it { should contain_file('/etc/init.d/supervisord') }
+        it { should contain_file('/etc/sysconfig/supervisor') }
       end
     end
   end

--- a/spec/defines/eventlistener_spec.rb
+++ b/spec/defines/eventlistener_spec.rb
@@ -31,7 +31,7 @@ describe 'supervisord::eventlistener', :type => :define do
       :stderr_logfile_maxbytes => '50MB',
       :stderr_logfile_backups  => '10',
       :stderr_events_enabled   => true,
-      :environment             => { 'env1' => 'value1', 'env2' => 'value2' },
+      :event_environment       => { 'env1' => 'value1', 'env2' => 'value2' },
       :directory               => '/opt/supervisord/chroot',
       :umask                   => '022',
       :serverurl               => 'AUTO'

--- a/spec/defines/fcgi_program_spec.rb
+++ b/spec/defines/fcgi_program_spec.rb
@@ -32,7 +32,7 @@ describe 'supervisord::fcgi_program', :type => :define do
       :stderr_logfile_backups  => '10',
       :stderr_capture_maxbytes => '0',
       :stderr_events_enabled   => true,
-      :environment             => { 'env1' => 'value1', 'env2' => 'value2' },
+      :program_environment     => { 'env1' => 'value1', 'env2' => 'value2' },
       :directory               => '/opt/supervisord/chroot',
       :umask                   => '022',
       :serverurl               => 'AUTO'

--- a/spec/defines/program_spec.rb
+++ b/spec/defines/program_spec.rb
@@ -31,7 +31,7 @@ describe 'supervisord::program', :type => :define do
       :stderr_logfile_backups  => '10',
       :stderr_capture_maxbytes => '0',
       :stderr_events_enabled   => true,
-      :environment             => { 'env1' => 'value1', 'env2' => 'value2' },
+      :program_environment     => { 'env1' => 'value1', 'env2' => 'value2' },
       :directory               => '/opt/supervisord/chroot',
       :umask                   => '022',
       :serverurl               => 'AUTO'

--- a/templates/init/Suse/defaults.erb
+++ b/templates/init/Suse/defaults.erb
@@ -1,0 +1,8 @@
+# this is sourced by the supervisord init script
+# written by jkoppe
+
+set -a 
+
+# should probably put both of these options as runtime arguments 
+OPTIONS="-c <%= @config_file %>"
+PIDFILE=<%= @run_path %>/<%= @pid_file %>

--- a/templates/init/Suse/init.erb
+++ b/templates/init/Suse/init.erb
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# supervisord   This scripts turns supervisord on
+#
+# Author:       Mike McGrath <mmcgrath@redhat.com> (based off yumupdatesd)
+#               Jason Koppe <jkoppe@indeed.com> adjusted to read sysconfig,
+#                   use supervisord tools to start/stop, conditionally wait
+#                   for child processes to shutdown, and startup later
+#
+# chkconfig:    345 83 04
+#
+# description:  supervisor is a process control utility.  It has a web based
+#               xmlrpc interface as well as a few other nifty features.
+# processname:  supervisord
+# config: <%= @config_file %>
+# pidfile: <%= @run_path %>/<%= @pid_file %>
+#
+
+<% if @scl_enabled -%>
+[ -e <%= @scl_script %> ] && . <%= @scl_script %>
+<% end -%>
+
+if [ -f /etc/rc.status ]; then
+    . /etc/rc.status
+    rc_reset
+fi
+
+# source function library
+if [ -f /etc/rc.d/init.d/functions ]; then
+    . /etc/rc.d/init.d/functions
+fi
+
+# source system settings
+[ -e <%= @init_defaults %> ] && . <%= @init_defaults %>
+
+RETVAL=0
+DAEMON=<%= @executable %>
+CTL=<%= @executable_ctl %>
+DESC=supervisord
+PIDFILE=<%= @run_path %>/<%= @pid_file %>
+
+# Tests if executable exists
+if [ ! -x $DAEMON ] ; then
+    echo "Executable not found ${DAEMON}"
+    exit 1
+fi
+
+running_pid()
+{
+    # Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] &&  return 1
+    (cat /proc/$pid/cmdline | tr "\000" "\n"|grep -q $name) || return 1
+    return 0
+}
+
+running()
+{
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    # Obtain the pid and check it against the binary name
+    pid=`cat $PIDFILE`
+    running_pid $pid $DAEMON || return 1
+    return 0
+}
+
+start() {
+    echo -n "Starting $DESC: "
+    if [ -e $PIDFILE ]; then 
+        echo "ALREADY STARTED"
+        return 1
+    else
+        # start supervisord with options from sysconfig (stuff like -c)
+        startproc -p $PIDFILE $DAEMON $OPTIONS
+        # only create the subsyslock if we created the PIDFILE
+        [ -e $PIDFILE ] && touch /var/lock/subsys/supervisord
+        return 0
+    fi
+}
+
+stop() {
+    echo -n "Stopping supervisord: "
+    killproc -p $PIDFILE $DESC 
+    # always remove the subsys.  we might have waited a while, but just remove it at this point.
+    rm -f /var/lock/subsys/supervisord
+    return 0
+}
+
+restart() {
+        stop
+        start
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|force-reload)
+        restart
+        ;;
+    reload)
+        $CTL $OPTIONS reload
+        RETVAL=$?
+        ;;
+    condrestart)
+        [ -f /var/lock/subsys/supervisord ] && restart
+        RETVAL=$?
+        ;;
+    status)
+        echo -n "supervisord is "
+        if running ;  then
+            echo "running"
+        else
+            echo "not running."
+            exit 1
+    fi
+    ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
+        exit 1
+esac
+
+exit $RETVAL


### PR DESCRIPTION
As perhttps://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html#variables-set-by-the-puppet-master , $environment is a global variable.

This PR renames $environment -> $prog_environment to fix this issue.