### PR TITLE
Fix default "$config_include" parameter value to make it consistent

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class supervisord::params {
   $minfds               = '1024'
   $minprocs             = '200'
   $umask                = '022'
-  $config_include       = '/etc/supervisor.d'
+  $config_include       = '/etc/supervisord.d'
   $config_file          = '/etc/supervisord.conf'
   $setuptools_url       = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/spec/acceptance/supervisord_spec.rb
+++ b/spec/acceptance/supervisord_spec.rb
@@ -44,11 +44,11 @@ describe 'supervisord::program' do
     end
 
     it 'should contain the correct values' do
-      cmd='grep command=echo /etc/supervisor.d/program_test.conf'
+      cmd='grep command=echo /etc/supervisord.d/program_test.conf'
       expect(shell(cmd).exit_code).to eq(0)
-      cmd='grep priority=100 /etc/supervisor.d/program_test.conf'
+      cmd='grep priority=100 /etc/supervisord.d/program_test.conf'
       expect(shell(cmd).exit_code).to eq(0)
-      cmd='grep "environment=" /etc/supervisor.d/program_test.conf'
+      cmd='grep "environment=" /etc/supervisord.d/program_test.conf'
       expect(shell(cmd).exit_code).to eq(0)
     end
   end
@@ -76,13 +76,13 @@ describe 'supervisord::fcgi-program' do
     end
 
     it 'should contain the correct values' do
-      cmd='grep socket=tcp://localhost:1000 /etc/supervisor.d/fcgi-program_test.conf'
+      cmd='grep socket=tcp://localhost:1000 /etc/supervisord.d/fcgi-program_test.conf'
       expect(shell(cmd).exit_code).to eq(0)
-      cmd="grep command=echo /etc/supervisor.d/fcgi-program_test.conf"
+      cmd="grep command=echo /etc/supervisord.d/fcgi-program_test.conf"
       expect(shell(cmd).exit_code).to eq(0)
-      cmd="grep priority=100 /etc/supervisor.d/fcgi-program_test.conf"
+      cmd="grep priority=100 /etc/supervisord.d/fcgi-program_test.conf"
       expect(shell(cmd).exit_code).to eq(0)
-      cmd='grep "environment=" /etc/supervisor.d/fcgi-program_test.conf'
+      cmd='grep "environment=" /etc/supervisord.d/fcgi-program_test.conf'
       expect(shell(cmd).exit_code).to eq(0)
     end
   end
@@ -105,9 +105,9 @@ describe 'supervisord::group' do
     end
 
     it 'should contain the correct values' do
-      cmd='grep "programs=test" /etc/supervisor.d/group_test.conf'
+      cmd='grep "programs=test" /etc/supervisord.d/group_test.conf'
       expect(shell(cmd).exit_code).to eq(0)
-      cmd="grep priority=100 /etc/supervisor.d/group_test.conf"
+      cmd="grep priority=100 /etc/supervisord.d/group_test.conf"
       expect(shell(cmd).exit_code).to eq(0)
     end
   end

--- a/spec/classes/supervisord_spec.rb
+++ b/spec/classes/supervisord_spec.rb
@@ -159,7 +159,7 @@ describe 'supervisord' do
 
   describe '#config_dirs' do
     context 'is specified' do
-      let(:params) {{ :config_dirs => ['/etc/supervisor.d/*.conf', '/opt/supervisor.d/*', '/usr/share/supervisor.d/*.config'] }}
+      let(:params) {{ :config_dirs => ['/etc/supervisord.d/*.conf', '/opt/supervisor.d/*', '/usr/share/supervisor.d/*.config'] }}
       it { should contain_concat__fragment('supervisord_main') \
         .with_content(/files=\/etc\/supervisor.d\/\*.conf \/opt\/supervisor.d\/\* \/usr\/share\/supervisor.d\/\*.config$/) }
     end

--- a/spec/classes/supervisord_spec.rb
+++ b/spec/classes/supervisord_spec.rb
@@ -147,7 +147,7 @@ describe 'supervisord' do
     context 'default' do
       it { should contain_file('/etc/supervisord.d') }
       it { should contain_concat__fragment('supervisord_main') \
-        .with_content(/files=\/etc\/supervisor.d\/\*.conf$/) }
+        .with_content(/files=\/etc\/supervisord.d\/\*.conf$/) }
     end
     context 'is specified' do
       let(:params) {{ :config_include => '/opt/supervisord/conf.d' }}
@@ -161,7 +161,7 @@ describe 'supervisord' do
     context 'is specified' do
       let(:params) {{ :config_dirs => ['/etc/supervisord.d/*.conf', '/opt/supervisor.d/*', '/usr/share/supervisor.d/*.config'] }}
       it { should contain_concat__fragment('supervisord_main') \
-        .with_content(/files=\/etc\/supervisor.d\/\*.conf \/opt\/supervisor.d\/\* \/usr\/share\/supervisor.d\/\*.config$/) }
+        .with_content(/files=\/etc\/supervisord.d\/\*.conf \/opt\/supervisor.d\/\* \/usr\/share\/supervisor.d\/\*.config$/) }
     end
   end
 

--- a/spec/classes/supervisord_spec.rb
+++ b/spec/classes/supervisord_spec.rb
@@ -145,7 +145,7 @@ describe 'supervisord' do
 
   describe '#config_include' do
     context 'default' do
-      it { should contain_file('/etc/supervisor.d') }
+      it { should contain_file('/etc/supervisord.d') }
       it { should contain_concat__fragment('supervisord_main') \
         .with_content(/files=\/etc\/supervisor.d\/\*.conf$/) }
     end

--- a/spec/defines/eventlistener_spec.rb
+++ b/spec/defines/eventlistener_spec.rb
@@ -42,36 +42,36 @@ describe 'supervisord::eventlistener', :type => :define do
     let(:params) { default_params }
 
     it { should contain_supervisord__eventlistener('foo') }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/\[eventlistener:foo\]/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/command=bar/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/process_name=\%\(process_num\)s/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/events=PROCESS_STATE,PROCESS_STATE_STARTING/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/buffer_size=10/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/numprocs=1/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/numprocs_start=0/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/priority=999/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/autostart=true/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/startsecs=1/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/startretries=3/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/exitcodes=0,2/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stopsignal=TERM/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stopwaitsecs=10/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stopasgroup=true/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/killasgroup=true/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/user=baz/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/redirect_stderr=true/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stdout_logfile=\/var\/log\/supervisor\/eventlistener_foo.log/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stdout_logfile_maxbytes=50MB/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stdout_logfile_backups=10/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stdout_events_enabled=true/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stderr_logfile=\/var\/log\/supervisor\/eventlistener_foo.error/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stderr_logfile_maxbytes=50MB/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stderr_logfile_backups=10/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stderr_events_enabled=true/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/environment=env1='value1',env2='value2'/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/directory=\/opt\/supervisord\/chroot/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/umask=022/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/serverurl=AUTO/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/\[eventlistener:foo\]/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/command=bar/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/process_name=\%\(process_num\)s/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/events=PROCESS_STATE,PROCESS_STATE_STARTING/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/buffer_size=10/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/numprocs=1/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/numprocs_start=0/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/priority=999/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/autostart=true/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/startsecs=1/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/startretries=3/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/exitcodes=0,2/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stopsignal=TERM/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stopwaitsecs=10/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stopasgroup=true/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/killasgroup=true/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/user=baz/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/redirect_stderr=true/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stdout_logfile=\/var\/log\/supervisor\/eventlistener_foo.log/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stdout_logfile_maxbytes=50MB/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stdout_logfile_backups=10/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stdout_events_enabled=true/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stderr_logfile=\/var\/log\/supervisor\/eventlistener_foo.error/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stderr_logfile_maxbytes=50MB/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stderr_logfile_backups=10/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stderr_events_enabled=true/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/environment=env1='value1',env2='value2'/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/directory=\/opt\/supervisord\/chroot/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/umask=022/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/serverurl=AUTO/) }
   end
 
   context 'ensure_process_stopped' do
@@ -91,8 +91,8 @@ describe 'supervisord::eventlistener', :type => :define do
       :numprocs => '2',
     }
     end
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/numprocs=2/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/numprocs=2/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
   end
 
   context 'absolute_log_paths' do
@@ -100,7 +100,7 @@ describe 'supervisord::eventlistener', :type => :define do
       :stdout_logfile => '/path/to/program_foo.log',
       :stderr_logfile => '/path/to/program_foo.error',
     }) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
-    it { should contain_file('/etc/supervisor.d/eventlistener_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
+    it { should contain_file('/etc/supervisord.d/eventlistener_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
   end
 end

--- a/spec/defines/fcgi_program_spec.rb
+++ b/spec/defines/fcgi_program_spec.rb
@@ -43,37 +43,37 @@ describe 'supervisord::fcgi_program', :type => :define do
     let(:params) { default_params }
 
     it { should contain_supervisord__fcgi_program('foo') }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/\[fcgi-program:foo\]/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/socket=tcp:\/\/localhost:1000/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/command=bar/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/process_name=\%\(process_num\)s/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/numprocs=1/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/numprocs_start=0/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/priority=999/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/autostart=true/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/startsecs=1/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/startretries=3/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/exitcodes=0,2/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stopsignal=TERM/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stopwaitsecs=10/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stopasgroup=true/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/killasgroup=true/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/user=baz/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/redirect_stderr=true/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stdout_logfile=\/var\/log\/supervisor\/fcgi-program_foo.log/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stdout_logfile_maxbytes=50MB/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stdout_logfile_backups=10/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stdout_capture_maxbytes=0/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stdout_events_enabled=true/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stderr_logfile=\/var\/log\/supervisor\/fcgi-program_foo.error/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stderr_logfile_maxbytes=50MB/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stderr_logfile_backups=10/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stderr_capture_maxbytes=0/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stderr_events_enabled=true/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/environment=env1='value1',env2='value2'/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/directory=\/opt\/supervisord\/chroot/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/umask=022/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/serverurl=AUTO/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/\[fcgi-program:foo\]/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/socket=tcp:\/\/localhost:1000/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/command=bar/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/process_name=\%\(process_num\)s/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/numprocs=1/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/numprocs_start=0/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/priority=999/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/autostart=true/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/startsecs=1/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/startretries=3/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/exitcodes=0,2/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stopsignal=TERM/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stopwaitsecs=10/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stopasgroup=true/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/killasgroup=true/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/user=baz/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/redirect_stderr=true/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stdout_logfile=\/var\/log\/supervisor\/fcgi-program_foo.log/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stdout_logfile_maxbytes=50MB/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stdout_logfile_backups=10/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stdout_capture_maxbytes=0/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stdout_events_enabled=true/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stderr_logfile=\/var\/log\/supervisor\/fcgi-program_foo.error/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stderr_logfile_maxbytes=50MB/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stderr_logfile_backups=10/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stderr_capture_maxbytes=0/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stderr_events_enabled=true/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/environment=env1='value1',env2='value2'/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/directory=\/opt\/supervisord\/chroot/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/umask=022/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/serverurl=AUTO/) }
   end
 
   context 'ensure_process_stopped' do
@@ -94,8 +94,8 @@ describe 'supervisord::fcgi_program', :type => :define do
       :socket   => 'tcp://localhost:1000',
     }
     end
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/numprocs=2/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/numprocs=2/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
   end
 
   context 'absolute_log_paths' do
@@ -103,7 +103,7 @@ describe 'supervisord::fcgi_program', :type => :define do
       :stdout_logfile => '/path/to/program_foo.log',
       :stderr_logfile => '/path/to/program_foo.error',
     }) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
-    it { should contain_file('/etc/supervisor.d/fcgi-program_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
+    it { should contain_file('/etc/supervisord.d/fcgi-program_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
   end
 end

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -6,17 +6,17 @@ describe 'supervisord::group', :type => :define do
   let(:facts) {{ :concat_basedir => '/var/lib/puppet/concat' }}
 
   it { should contain_supervisord__group('foo').with_program }
-  it { should contain_file('/etc/supervisor.d/group_foo.conf').with_content(/programs=bar,baz/) }
+  it { should contain_file('/etc/supervisord.d/group_foo.conf').with_content(/programs=bar,baz/) }
 
   describe '#priority' do
     it 'should default to undef' do
-      should_not contain_file('/etc/supervisor.d/group_foo.conf').with_content(/priority/)
-      should contain_file('/etc/supervisor.d/group_foo.conf').with_content(/programs=bar,baz/)
+      should_not contain_file('/etc/supervisord.d/group_foo.conf').with_content(/priority/)
+      should contain_file('/etc/supervisord.d/group_foo.conf').with_content(/programs=bar,baz/)
     end
     context '100' do
       let(:params) {{ :priority => '100', :programs => ['bar', 'baz'] }}
-      it { should contain_file('/etc/supervisor.d/group_foo.conf').with_content(/priority=100/) }
-      it { should contain_file('/etc/supervisor.d/group_foo.conf').with_content(/programs=bar,baz/) }
+      it { should contain_file('/etc/supervisord.d/group_foo.conf').with_content(/priority=100/) }
+      it { should contain_file('/etc/supervisord.d/group_foo.conf').with_content(/programs=bar,baz/) }
     end
   end
 end

--- a/spec/defines/program_spec.rb
+++ b/spec/defines/program_spec.rb
@@ -42,36 +42,36 @@ describe 'supervisord::program', :type => :define do
     let(:params) { default_params }
 
     it { should contain_supervisord__program('foo') }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/\[program:foo\]/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/command=bar/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/process_name=\%\(process_num\)s/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/numprocs=1/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/numprocs_start=0/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/priority=999/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/autostart=true/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/startsecs=1/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/startretries=3/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/exitcodes=0,2/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stopsignal=TERM/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stopwaitsecs=10/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stopasgroup=true/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/killasgroup=true/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/user=baz/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/redirect_stderr=true/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_logfile=\/var\/log\/supervisor\/program_foo.log/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_logfile_maxbytes=50MB/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_logfile_backups=10/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_capture_maxbytes=0/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_events_enabled=true/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_logfile=\/var\/log\/supervisor\/program_foo.error/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_logfile_maxbytes=50MB/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_logfile_backups=10/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_capture_maxbytes=0/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_events_enabled=true/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/environment=env1='value1',env2='value2'/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/directory=\/opt\/supervisord\/chroot/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/umask=022/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/serverurl=AUTO/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/\[program:foo\]/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/command=bar/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/process_name=\%\(process_num\)s/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/numprocs=1/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/numprocs_start=0/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/priority=999/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/autostart=true/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/startsecs=1/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/startretries=3/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/exitcodes=0,2/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stopsignal=TERM/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stopwaitsecs=10/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stopasgroup=true/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/killasgroup=true/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/user=baz/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/redirect_stderr=true/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stdout_logfile=\/var\/log\/supervisor\/program_foo.log/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stdout_logfile_maxbytes=50MB/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stdout_logfile_backups=10/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stdout_capture_maxbytes=0/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stdout_events_enabled=true/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stderr_logfile=\/var\/log\/supervisor\/program_foo.error/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stderr_logfile_maxbytes=50MB/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stderr_logfile_backups=10/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stderr_capture_maxbytes=0/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stderr_events_enabled=true/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/environment=env1='value1',env2='value2'/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/directory=\/opt\/supervisord\/chroot/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/umask=022/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/serverurl=AUTO/) }
   end
 
   context 'ensure_process_stopped' do
@@ -91,8 +91,8 @@ describe 'supervisord::program', :type => :define do
       :numprocs => '2',
     }
     end
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/numprocs=2/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/numprocs=2/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/process_name=\%\(program_name\)s_\%\(process_num\)02d/) }
   end
 
   context 'absolute_log_paths' do
@@ -100,7 +100,7 @@ describe 'supervisord::program', :type => :define do
       :stdout_logfile => '/path/to/program_foo.log',
       :stderr_logfile => '/path/to/program_foo.error',
     }) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
-    it { should contain_file('/etc/supervisor.d/program_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stdout_logfile=\/path\/to\/program_foo.log/) }
+    it { should contain_file('/etc/supervisord.d/program_foo.conf').with_content(/stderr_logfile=\/path\/to\/program_foo.error/) }
   end
 end

--- a/spec/defines/rpcinterface_spec.rb
+++ b/spec/defines/rpcinterface_spec.rb
@@ -10,17 +10,17 @@ describe 'supervisord::rpcinterface', :type  => :define do
   context 'default' do
     let(:params) { default_params }
     it { should contain_supervisord__rpcinterface('foo') }
-    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/\[rpcinterface:foo\]/) }
-    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/supervisor\.rpcinterface_factory = bar:baz/) }
-    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').without_content(/retries/) }
+    it { should contain_file('/etc/supervisord.d/rpcinterface_foo.conf').with_content(/\[rpcinterface:foo\]/) }
+    it { should contain_file('/etc/supervisord.d/rpcinterface_foo.conf').with_content(/supervisor\.rpcinterface_factory = bar:baz/) }
+    it { should contain_file('/etc/supervisord.d/rpcinterface_foo.conf').without_content(/retries/) }
   end
 
   context 'retries' do
     let(:params) { { :retries => 2 }.merge(default_params) }
     it { should contain_supervisord__rpcinterface('foo') }
-    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/\[rpcinterface:foo\]/) }
-    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/supervisor\.rpcinterface_factory = bar:baz/) }
-    it { should contain_file('/etc/supervisor.d/rpcinterface_foo.conf').with_content(/retries = 2/) }
+    it { should contain_file('/etc/supervisord.d/rpcinterface_foo.conf').with_content(/\[rpcinterface:foo\]/) }
+    it { should contain_file('/etc/supervisord.d/rpcinterface_foo.conf').with_content(/supervisor\.rpcinterface_factory = bar:baz/) }
+    it { should contain_file('/etc/supervisord.d/rpcinterface_foo.conf').with_content(/retries = 2/) }
   end
 
 end


### PR DESCRIPTION
Fix default "$config_include" parameter value to make it consistent with the default expected value.

I've seen that the default value is missing the final "d" in the directory name. I've changed the defined directory in the "specs"