### PR TITLE
Fix variable name ($use_ctl_socket) in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,7 +110,7 @@ class supervisord(
     $use_ctl_socket = 'unix'
   }
   elsif $inet_server {
-    $use_unix_socket = 'inet'
+    $use_ctl_socket = 'inet'
   }
 
   if $use_ctl_socket == 'unix' {


### PR DESCRIPTION
The variable name is use_ctl_socket, not use_unix_socket.

