### PR TITLE
Fix: service manage handling

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,11 +42,7 @@ class supervisord::params {
   $package_provider     = 'pip'
   $package_install_options = undef
   $service_manage       = true
-  if ($supervisord::service_manage == true) {
-    $service_ensure       = 'running'
-  } else {
-    $service_ensure       = undef
-  }
+  $service_ensure       = 'running'
   $service_enable       = true
   $service_name         = 'supervisord'
   $service_restart      = undef

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -3,17 +3,19 @@
 # Class to reread and update supervisord with supervisorctl
 #
 class supervisord::reload inherits supervisord {
+  if $::supervisord::service_manage {
+    $supervisorctl = $::supervisord::executable_ctl
 
-  $supervisorctl = $::supervisord::executable_ctl
-
-  exec { 'supervisorctl_reread':
-    command     => "${supervisorctl} reread",
-    refreshonly => true,
-    require     => Service[$supervisord::service_name],
-  }
-  exec { 'supervisorctl_update':
-    command     => "${supervisorctl} update",
-    refreshonly => true,
-    require     => Service[$supervisord::service_name],
+    exec { 'supervisorctl_reread':
+      command     => "${supervisorctl} reread",
+      refreshonly => true,
+      require     => Service[$::supervisord::service_name],
+    }
+    exec { 'supervisorctl_update':
+      command     => "${supervisorctl} update",
+      refreshonly => true,
+      require     => Service[$::supervisord::service_name],
+    }
   }
 }
+

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,11 +3,13 @@
 # Class for the supervisord service
 #
 class supervisord::service inherits supervisord  {
-  service { $supervisord::service_name:
-    ensure     => $supervisord::service_ensure,
-    enable     => $supervisord::service_enable,
-    hasrestart => true,
-    hasstatus  => true,
-    restart    => $supervisord::service_restart,
+  if $::supervisord::service_manage {
+    service { $::supervisord::service_name:
+      ensure     => $::supervisord::service_ensure,
+      enable     => $::supervisord::service_enable,
+      hasrestart => true,
+      hasstatus  => true,
+      restart    => $::supervisord::service_restart,
+    }
   }
 }


### PR DESCRIPTION
Setting the default value of service_ensure in params.pp
was made dependent on service_manage in a broken way.

Error message: "Scope(Class[Supervisord::Params]): Could not look up
qualified variable 'supervisord::service_manage'; class supervisord has
not been evaluated"

The issue is now fixed in that way:
 - the default for $service_ensure is set to 'running' independent from
   $server_manage
 - make all the actions inside service.pp, and reload.pp
   dependent on the $service_manage variable.
   only when it is set to true, manage the service, or
   try attempting to reload it.