### PR TITLE
Add support for ensure_process = running

### DIFF
--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -128,6 +128,19 @@ define supervisord::program(
         process => $name
       }
     }
+    'running': {
+      supervisord::supervisorctl { "running_${name}":
+        command     => 'start',
+        process     => $name,
+        refreshonly => true
+      }
+      exec { "test_if_start_needed_for_${name}":
+        command => 'echo "noop" > /dev/null',
+        notify  =>  Supervisord::Supervisorctl["running_${name}"],
+        path    => [ '/bin', '/usr/bin' ],
+        unless  => "test `${::supervisord::executable_ctl} status ${name} | awk {'print \$2'}` = 'RUNNING'"
+      }
+    }
     default: { }
   }
 }


### PR DESCRIPTION
This deals with #75.
For sanity it does a check if the process is already running before trying to start it again.