### PR TITLE
make configuration file mode configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,7 +52,7 @@ class supervisord::config inherits supervisord {
     concat { $supervisord::config_file:
       owner  => 'root',
       group  => '0',
-      mode   => '0644',
+      mode   => $supervisord::config_file_mode,
       notify => Class['supervisord::service']
     }
 

--- a/manifests/eventlistener.pp
+++ b/manifests/eventlistener.pp
@@ -40,7 +40,8 @@ define supervisord::eventlistener(
   $event_environment       = undef,
   $directory               = undef,
   $umask                   = undef,
-  $serverurl               = undef
+  $serverurl               = undef,
+  $config_file_mode        = '0644'
 ) {
 
   include supervisord
@@ -75,6 +76,7 @@ define supervisord::eventlistener(
   if $stderr_events_enabled { validate_bool($stderr_events_enabled) }
   if $directory { validate_absolute_path($directory) }
   if $umask { validate_re($umask, '^[0-7][0-7][0-7]$') }
+  validate_re($config_file_mode, '^0[0-7][0-7][0-7]$')
 
   # create the correct log variables
   $stdout_logfile_path = $stdout_logfile ? {
@@ -116,7 +118,7 @@ define supervisord::eventlistener(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0644',
+    mode    => $config_file_mode,
     content => template('supervisord/conf/eventlistener.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/fcgi_program.pp
+++ b/manifests/fcgi_program.pp
@@ -42,7 +42,8 @@ define supervisord::fcgi_program(
   $program_environment     = undef,
   $directory               = undef,
   $umask                   = undef,
-  $serverurl               = undef
+  $serverurl               = undef,
+  $config_file_mode        = '0644'
 ) {
 
   include supervisord
@@ -78,6 +79,7 @@ define supervisord::fcgi_program(
   if $stderr_events_enabled { validate_bool($stderr_events_enabled) }
   if $directory { validate_absolute_path($directory) }
   if $umask { validate_re($umask, '^[0-7][0-7][0-7]$') }
+  validate_re($config_file_mode, '^0[0-7][0-7][0-7]$')
 
   # create the correct log variables
   $stdout_logfile_path = $stdout_logfile ? {
@@ -115,7 +117,7 @@ define supervisord::fcgi_program(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0644',
+    mode    => $config_file_mode,
     content => template('supervisord/conf/fcgi_program.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -7,8 +7,9 @@
 #
 define supervisord::group (
   $programs,
-  $ensure   = present,
-  $priority = undef
+  $ensure           = present,
+  $priority         = undef,
+  $config_file_mode = '0644'
 ) {
 
   include supervisord
@@ -16,6 +17,7 @@ define supervisord::group (
   # parameter validation
   validate_array($programs)
   if $priority { if !is_integer($priority) { validate_re($priority, '^\d+', "invalid priority value of: ${priority}") } }
+  validate_re($config_file_mode, '^0[0-7][0-7][0-7]$')
 
   $progstring = array2csv($programs)
   $conf = "${supervisord::config_include}/group_${name}.conf"
@@ -23,7 +25,7 @@ define supervisord::group (
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0644',
+    mode    => $config_file_mode,
     content => template('supervisord/conf/group.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class supervisord(
   $config_include       = $supervisord::params::config_include,
   $config_include_purge = false,
   $config_file          = $supervisord::params::config_file,
+  $config_file_mode     = $supervisord::params::config_file_mode,
   $config_dirs          = undef,
   $umask                = $supervisord::params::umask,
 
@@ -105,6 +106,7 @@ class supervisord(
   validate_re($umask, '^0[0-7][0-7]$', "invalid umask: ${umask}.")
   validate_re($unix_socket_mode, '^[0-7][0-7][0-7][0-7]$', "invalid unix_socket_mode: ${unix_socket_mode}")
   validate_re($ctl_socket, ['^unix$', '^inet$'], "invalid ctl_socket: ${ctl_socket}")
+  validate_re($config_file_mode, '^0[0-7][0-7][0-7]$')
 
   if ! is_integer($logfile_backups) { fail("invalid logfile_backups: ${logfile_backups}.")}
   if ! is_integer($minfds) { fail("invalid minfds: ${minfds}.")}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,6 +97,7 @@ class supervisord::params {
   $manage_config           = true
   $config_include          = '/etc/supervisor.d'
   $config_file             = '/etc/supervisord.conf'
+  $config_file_mode        = '0644'
   $setuptools_url          = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
 
   $ctl_socket              = 'unix'

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -39,7 +39,8 @@ define supervisord::program(
   $environment             = undef,
   $directory               = undef,
   $umask                   = undef,
-  $serverurl               = undef
+  $serverurl               = undef,
+  $cfg_file_mode           = '0644'
 ) {
 
   include supervisord
@@ -74,6 +75,7 @@ define supervisord::program(
   if $stderr_events_enabled { validate_bool($stderr_events_enabled) }
   if $directory { validate_absolute_path($directory) }
   if $umask { validate_re($umask, '^[0-7][0-7][0-7]$') }
+  validate_re($cfg_file_mode, '^0[0-7][0-7][0-7]$')
 
   # create the correct log variables
   $stdout_logfile_path = $stdout_logfile ? {
@@ -111,7 +113,7 @@ define supervisord::program(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0644',
+    mode    => $cfg_file_mode,
     content => template('supervisord/conf/program.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -40,7 +40,7 @@ define supervisord::program(
   $directory               = undef,
   $umask                   = undef,
   $serverurl               = undef,
-  $cfg_file_mode           = '0644'
+  $config_file_mode        = '0644'
 ) {
 
   include supervisord
@@ -75,7 +75,7 @@ define supervisord::program(
   if $stderr_events_enabled { validate_bool($stderr_events_enabled) }
   if $directory { validate_absolute_path($directory) }
   if $umask { validate_re($umask, '^[0-7][0-7][0-7]$') }
-  validate_re($cfg_file_mode, '^0[0-7][0-7][0-7]$')
+  validate_re($config_file_mode, '^0[0-7][0-7][0-7]$')
 
   # create the correct log variables
   $stdout_logfile_path = $stdout_logfile ? {
@@ -113,7 +113,7 @@ define supervisord::program(
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => $cfg_file_mode,
+    mode    => $config_file_mode,
     content => template('supervisord/conf/program.erb'),
     notify  => Class['supervisord::reload']
   }

--- a/manifests/rpcinterface.pp
+++ b/manifests/rpcinterface.pp
@@ -9,19 +9,21 @@ define supervisord::rpcinterface (
   $rpcinterface_factory,
   $ensure                = present,
   $retries               = undef,
+  $config_file_mode      = '0644'
 ) {
 
   include supervisord
 
   # parameter validation
   if $retries { if !is_integer($retries) { validate_re($retries, '^\d+')}}
+  validate_re($config_file_mode, '^0[0-7][0-7][0-7]$')
 
   $conf = "${supervisord::config_include}/rpcinterface_${name}.conf"
 
   file { $conf:
     ensure  => $ensure,
     owner   => 'root',
-    mode    => '0644',
+    mode    => $config_file_mode,
     content => template('supervisord/conf/rpcinterface.erb'),
     notify  => Class['supervisord::reload']
   }


### PR DESCRIPTION
This is useful e.g. if the configuration file stores database credentials in environment variables, in which case a mode of e.g. '0400' is appropriate.