### PR TITLE
Brutus333 patch 1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class supervisord(
   $service_name            = $supervisord::params::service_name,
   $service_restart         = $supervisord::params::service_restart,
   $install_pip             = false,
+  $pip_proxy               = undef,
   $install_init            = $supervisord::params::install_init,
   $init_type               = $supervisord::params::init_type,
   $init_script             = $supervisord::params::init_script,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,9 +3,20 @@
 # Installs supervisor package (defaults to using pip)
 #
 class supervisord::install inherits supervisord {
-  package { $supervisord::package_name:
-    ensure          => $supervisord::package_ensure,
-    provider        => $supervisord::package_provider,
-    install_options => $supervisord::package_install_options,
+  if $::supervisord::pip_proxy {
+    exec { "pip-install-supervisor":
+      user        => root,
+      path        => ["/usr/bin","/bin"],
+      environment => [ "http_proxy=${supervisord::pip_proxy}", "https_proxy=${supervisord::pip_proxy}" ],
+      command     => "pip install ${supervisord::package_name}",
+      unless      => "which supervisorctl",
+    }
+  }
+  else {
+    package { $supervisord::package_name:
+      ensure          => $supervisord::package_ensure,
+      provider        => $supervisord::package_provider,
+      install_options => $supervisord::package_install_options,
+    }
   }
 }


### PR DESCRIPTION
In cases where node does not have direct internet connection, a proxy is required to install supervisord with pip. 
Since older version of pip does not honor proxy configuration setting the simplest way is to use exec with environment.
We tried also setting the proxy in puppet.conf file but this has the unwanted effect of using the proxy for puppet agent-master communication.