### PR TITLE
Updating the canonical location of the ez_setup.py script

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,7 +98,7 @@ class supervisord::params {
   $config_include          = '/etc/supervisor.d'
   $config_file             = '/etc/supervisord.conf'
   $config_file_mode        = '0644'
-  $setuptools_url          = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
+  $setuptools_url          = 'https://bootstrap.pypa.io/ez_setup.py'
 
   $ctl_socket              = 'unix'
 


### PR DESCRIPTION
setuptools has been moved from bitbucket to github.

Also see the changes in the changes.srt file in this commit 

https://github.com/pypa/setuptools/commit/a73118b9e3c125910ce3a50ab1e676632b4c12d1