### PR TITLE
Allow to not autoreload on change to configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,8 @@ class supervisord(
   $executable              = $supervisord::params::executable,
   $executable_ctl          = $supervisord::params::executable_ctl,
 
+  $autoreload_programs  = $supervisord::params::autoreload_programs,
+
   $scl_enabled             = $supervisord::params::scl_enabled,
   $scl_script              = $supervisord::params::scl_script,
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,6 +100,8 @@ class supervisord::params {
   $config_file_mode        = '0644'
   $setuptools_url          = 'https://bootstrap.pypa.io/ez_setup.py'
 
+  $autoreload_programs = true
+
   $ctl_socket              = 'unix'
 
   $unix_socket             = true
@@ -117,5 +119,5 @@ class supervisord::params {
   $inet_username           = undef
   $inet_password           = undef
 
-  
+
 }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -115,7 +115,10 @@ define supervisord::program(
     owner   => 'root',
     mode    => $config_file_mode,
     content => template('supervisord/conf/program.erb'),
-    if $supervisord::autoreload_programs {
+  }
+
+  if $supervisord::autoreload_programs {
+    File[$conf] {
       notify  => Class['supervisord::reload']
     }
   }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -115,7 +115,9 @@ define supervisord::program(
     owner   => 'root',
     mode    => $config_file_mode,
     content => template('supervisord/conf/program.erb'),
-    notify  => Class['supervisord::reload']
+    if $supervisord::autoreload_programs {
+      notify  => Class['supervisord::reload']
+    }
   }
 
   case $ensure_process {


### PR DESCRIPTION
We use this to roll out our deployment so we can have puppet manage the configuration but only when we are ready to reread/update when our servers are out of the LB.
