### PR TITLE
 When running as a different user the config dir, pid dir and log dir should be owned by that user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,14 +16,16 @@ class supervisord::config inherits supervisord {
 
   file { $supervisord::log_path:
     ensure => directory,
-    owner  => 'root',
+    owner  => $supervisord::user,
+    group  => $supervisord::group,
     mode   => '0644'
   }
 
   if $supervisord::run_path != '/var/run' {
     file { $supervisord::run_path:
       ensure => directory,
-      owner  => 'root',
+      owner  => $supervisord::user,
+      group  => $supervisord::group,
       mode   => '0644'
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,8 @@ class supervisord::config inherits supervisord {
   if ($supervisord::manage_config) {
     file { $supervisord::config_include:
       ensure  => directory,
-      owner   => 'root',
+      owner   => $supervisord::user,
+      group   => $supervisord::group,
       mode    => '0755',
       recurse => $supervisord::config_include_purge,
       purge   => $supervisord::config_include_purge,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,8 @@ class supervisord(
   $inet_username        = $supervisord::params::inet_username,
   $inet_password        = $supervisord::params::inet_password,
 
-  $user                 = undef,
+  $user                 = $supervisord::params::user,
+  $group                = $supervisord::params::group,
   $identifier           = undef,
   $childlogdir          = undef,
   $environment          = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,6 +116,8 @@ class supervisord::params {
   $inet_auth               = false
   $inet_username           = undef
   $inet_password           = undef
-
+  
+  $user                    = 'root'
+  $group                   = 'root'
   
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,8 +116,6 @@ class supervisord::params {
   $inet_auth               = false
   $inet_username           = undef
   $inet_password           = undef
-  
   $user                    = 'root'
   $group                   = 'root'
-  
 }


### PR DESCRIPTION
There is the nice option to run supervisord as a different user, but the pid, config and log directories might not be owned by that user (causing some problems). This pull requests tries to address this issue.