### PR TITLE
Use systemd for Ubuntu 16.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,7 +42,7 @@ class supervisord::params {
     }
     'Debian': {
       case $::operatingsystemmajrelease {
-        '8': {
+        '8', '16.04': {
           $init_type     = 'systemd'
           $init_script   = '/etc/systemd/system/supervisord.service'
           $init_defaults = false


### PR DESCRIPTION
For Xenial, `$::osfamily` is detected as `Debian`, but `$::operatingsystemmajrelease` is `16.04`. Therefore this module is still creating an init script.