### PR TITLE
Systemd unit file should not be executable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,7 +35,7 @@ class supervisord::config inherits supervisord {
     file { $supervisord::init_script:
       ensure  => present,
       owner   => 'root',
-      mode    => '0755',
+      mode    => $supervisord::init_mode,
       content => template($supervisord::init_script_template),
       notify  => Class['supervisord::service'],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class supervisord(
   $pip_proxy               = undef,
   $install_init            = $supervisord::params::install_init,
   $init_type               = $supervisord::params::init_type,
+  $init_mode               = $supervisord::params::init_mode,
   $init_script             = $supervisord::params::init_script,
   $init_script_template    = $supervisord::params::init_script_template,
   $init_defaults           = $supervisord::params::init_defaults,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,6 +79,16 @@ class supervisord::params {
       $executable_path   = '/usr/local/bin'
     }
   }
+
+  case $init_type {
+    'systemd': {
+      $init_mode = '0644'
+    }
+    'init', default: {
+      $init_mode = '0755'
+    }
+  }
+
   $init_script_template   = "supervisord/init/${::osfamily}/${init_type}.erb"
   $init_defaults_template = "supervisord/init/${::osfamily}/defaults.erb"
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,13 +80,10 @@ class supervisord::params {
     }
   }
 
-  case $init_type {
-    'systemd': {
-      $init_mode = '0644'
-    }
-    'init', default: {
-      $init_mode = '0755'
-    }
+  $init_mode = $init_type ? {
+    'systemd' => '0644',
+    'init'    => '0755',
+    default   => '0755'
   }
 
   $init_script_template   = "supervisord/init/${::osfamily}/${init_type}.erb"


### PR DESCRIPTION
The systemd unit file should not be executable. I was receiving the following message in syslog:
`systemd[1]: Configuration file /etc/systemd/system/supervisord.service is marked executable. Please remove executable permission bits. Proceeding anyway.`

I introduced a new variable `init_mode` which value will change depending on the `init_type`. 