### PR TITLE
Notify supervisord on config directory change.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class supervisord::config inherits supervisord {
       mode    => '0755',
       recurse => $supervisord::config_include_purge,
       purge   => $supervisord::config_include_purge,
+      notify  => Class['supervisord::service'],
     }
   }
 


### PR DESCRIPTION
Problematic situation:

```
class { 'supervisord':
    ...
    config_include       => '/etc/supervisor/conf.d',
    config_include_purge => true,
    ...
}
```

If we remove any `supervisord::program` block with this configuration, it's .conf file gets deleted, but supervisord process is not reloaded and removed program remains running.

This patch reconfigures supervisord on the conf directory content change.