### PR TITLE
Remove running programs when configs are removed.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,7 @@ class supervisord::config inherits supervisord {
       mode    => '0755',
       recurse => $supervisord::config_include_purge,
       purge   => $supervisord::config_include_purge,
+      notify  => Class['supervisord::reload'],
     }
   }
 


### PR DESCRIPTION
When you remove a Supervisord program with param `config_include_purge => true`, the config file is removed but Supervisord isn't notified so the process is still running.

This change triggers `supervisord::reload` (reread and update) to remove the program.  

Similar to PR https://github.com/ajcrowe/puppet-supervisord/pull/125, but does a supervisord::reload instead of a supervisors::service, which restarts the Supervisord daemon.