### PR TITLE
Use equeffelec init script variant for killproc timeout

### DIFF
--- a/templates/init/RedHat/defaults.erb
+++ b/templates/init/RedHat/defaults.erb
@@ -1,8 +1,18 @@
-# this is sourced by the supervisord init script
-# written by jkoppe
+# Configuration file for the supervisord service
+#
+# Author: Jason Koppe <jkoppe@indeed.com>
+#             orginal work
+#         Erwan Queffelec <erwan.queffelec@gmail.com>
+#             adjusted to new LSB-compliant init script
 
-set -a 
+# WARNING: change these wisely! for instance, adding -d, --nodaemon
+# here will lead to a very undesirable (blocking) behavior
+#OPTIONS="-c <%= @config_file %>"
+#PIDFILE=<%= @run_path %>/<%= @pid_file %>
+#LOCKFILE=/var/lock/subsys/supervisord
 
-# should probably put both of these options as runtime arguments 
-OPTIONS="-c <%= @config_file %>"
-PIDFILE=<%= @run_path %>/<%= @pid_file %>
+# Path to the supervisord binary
+#SUPERVISORD=<%= @executable %>
+
+# How long should we wait before forcefully killing the supervisord process ?
+#STOP_TIMEOUT=60

--- a/templates/init/RedHat/init.erb
+++ b/templates/init/RedHat/init.erb
@@ -1,92 +1,96 @@
 #!/bin/bash
 #
-# supervisord   This scripts turns supervisord on
+# supervisord   Startup script for the Supervisor process control system
 #
 # Author:       Mike McGrath <mmcgrath@redhat.com> (based off yumupdatesd)
 #               Jason Koppe <jkoppe@indeed.com> adjusted to read sysconfig,
 #                   use supervisord tools to start/stop, conditionally wait
 #                   for child processes to shutdown, and startup later
+#               Erwan Queffelec <erwan.queffelec@gmail.com>
+#                   make script LSB-compliant
+#               Greg Smethells <gsmethells@mgmail.com>
+#.                  Allow supervisorctl to be overridden
 #
 # chkconfig:    345 83 04
-#
-# description:  supervisor is a process control utility.  It has a web based
-#               xmlrpc interface as well as a few other nifty features.
-# processname:  supervisord
+# description: Supervisor is a client/server system that allows \
+#   its users to monitor and control a number of processes on \
+#   UNIX-like operating systems.
+# processname: supervisord
 # config: <%= @config_file %>
+# config: <%= @init_defaults %>
 # pidfile: <%= @run_path %>/<%= @pid_file %>
 #
-
+### BEGIN INIT INFO
+# Provides: supervisord
+# Required-Start: $all
+# Required-Stop: $all
+# Short-Description: start and stop Supervisor process control system
+# Description: Supervisor is a client/server system that allows
+#   its users to monitor and control a number of processes on
+#   UNIX-like operating systems.
+### END INIT INFO
 <% if @scl_enabled -%>
-[ -e <%= @scl_script %> ] && . <%= @scl_script %>
+
+if [ -e <%= @scl_script %> ]; then
+    . <%= @scl_script %>
+fi
 <% end -%>
 
-# source function library
+# Source function library
 . /etc/rc.d/init.d/functions
 
-# source system settings
-[ -e <%= @init_defaults %> ] && . <%= @init_defaults %>
-
-RETVAL=0
-DAEMON=<%= @executable %>
-CTL=<%= @executable_ctl %>
-DESC=supervisord
-PIDFILE=<%= @run_path %>/<%= @pid_file %>
-
-# Tests if executable exists
-if [ ! -x $DAEMON ] ; then
-    echo "Executable not found ${DAEMON}"
-    exit 1
+# Source system settings
+if [ -f <%= @init_defaults %> ]; then
+    . <%= @init_defaults %>
 fi
 
-running_pid()
-{
-    # Check if a given process pid's cmdline matches a given name
-    pid=$1
-    name=$2
-    [ -z "$pid" ] && return 1
-    [ ! -d /proc/$pid ] &&  return 1
-    (cat /proc/$pid/cmdline | tr "\000" "\n"|grep -q $name) || return 1
-    return 0
-}
-
-running()
-{
-# Check if the process is running looking at /proc
-# (works for all users)
-
-    # No pidfile, probably no daemon present
-    [ ! -f "$PIDFILE" ] && return 1
-    # Obtain the pid and check it against the binary name
-    pid=`cat $PIDFILE`
-    running_pid $pid $DAEMON || return 1
-    return 0
-}
+# Path to the supervisorctl script, server binary,
+# and short-form for messages.
+supervisorctl=${SUPERVISORCTL-<%= @executable_ctl %>}
+supervisord=${SUPERVISORD-<%= @executable %>}
+prog=supervisord
+pidfile=${PIDFILE-<%= @run_path %>/<%= @pid_file %>}
+lockfile=${LOCKFILE-/var/lock/subsys/supervisord}
+sockfile=${SOCKFILE-<%= @run_path %>/<%= @unix_socket_file %>}
+STOP_TIMEOUT=${STOP_TIMEOUT-60}
+OPTIONS="${OPTIONS--c <%= @config_file %>}"
+RETVAL=0
 
 start() {
-    echo -n "Starting $DESC: "
-    if [ -e $PIDFILE ]; then 
-        echo "ALREADY STARTED"
-        return 1
-    else
-        # start supervisord with options from sysconfig (stuff like -c)
-        daemon $DAEMON $OPTIONS
-        # only create the subsyslock if we created the PIDFILE
-        [ -e $PIDFILE ] && touch /var/lock/subsys/supervisord
-        return 0
+    echo -n $"Starting $prog: "
+    daemon --pidfile=${pidfile} $supervisord $OPTIONS
+    RETVAL=$?
+    echo
+    if [ $RETVAL -eq 0 ]; then
+        touch ${lockfile}
+        $supervisorctl $OPTIONS status
     fi
+    return $RETVAL
 }
 
 stop() {
-    echo -n "Stopping supervisord: "
-    killproc -p $PIDFILE $DESC 
-    # always remove the subsys.  we might have waited a while, but just remove it at this point.
-    rm -f /var/lock/subsys/supervisord
-    return 0
+    echo -n $"Stopping $prog: "
+    killproc -p ${pidfile} -d ${STOP_TIMEOUT} $supervisord
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -rf ${lockfile} ${pidfile} ${sockfile}
+}
+
+reload() {
+    echo -n $"Reloading $prog: "
+    LSB=1 killproc -p $pidfile $supervisord -HUP
+    RETVAL=$?
+    echo
+    if [ $RETVAL -eq 7 ]; then
+        failure $"$prog reload"
+    else
+        $supervisorctl $OPTIONS status
+    fi
 }
 
 restart() {
-        stop
-        start
+    stop
+    start
 }
 
 case "$1" in
@@ -96,29 +100,26 @@ case "$1" in
     stop)
         stop
         ;;
-    restart|force-reload)
+    status)
+        status -p ${pidfile} $supervisord
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && $supervisorctl $OPTIONS status
+        ;;
+    restart)
         restart
         ;;
-    reload)
-        $CTL $OPTIONS reload
-        RETVAL=$?
+    condrestart|try-restart)
+        if status -p ${pidfile} $supervisord >&/dev/null; then
+          stop
+          start
+        fi
         ;;
-    condrestart)
-        [ -f /var/lock/subsys/supervisord ] && restart
-        RETVAL=$?
+    force-reload|reload)
+        reload
         ;;
-    status)
-        echo -n "supervisord is "
-        if running ;  then
-            echo "running"
-        else
-            echo "not running."
-            exit 1
-    fi
-    ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
-        exit 1
+        echo $"Usage: $prog {start|stop|restart|condrestart|try-restart|force-reload|reload}"
+        RETVAL=2
 esac
 
 exit $RETVAL


### PR DESCRIPTION
* Old init script was rapidly killing the process, without allowing for
child processes to be terminated cleanly.
* Remove open file limit change from sysconfig, it wasn't replicated in
the original.