### PR TITLE
fix refresh when service_manage = false

### DIFF
--- a/lib/facter/service_manager.rb
+++ b/lib/facter/service_manager.rb
@@ -1,0 +1,24 @@
+# Reports which process supervisor runs this node, so Puppet can dispatch
+# supervisord::program to the right backend WITHOUT an explicit
+# sc::service_manager hiera key. The catalog compiles on the server, so the
+# only way the server learns the node's backend is a fact the node reports;
+# this is that fact.
+#
+# Returns 'zpinit' when zpinit is the node's supervisor, else 'supervisor'.
+# Any one of three ground-truth signals marks a zpinit node (the ScaleCommerce
+# zpinit image bakes all three, so detection is reliable even on the first
+# Puppet run before any service is up):
+#   - /usr/local/bin/zpinit exists  (binary baked into the image)
+#   - /run/zpinit.sock is a socket  (zpinit is running, control socket bound)
+#   - PID 1 is zpinit               (zpinit is the container's supervisor)
+# sc::service_manager remains available as an explicit override in hiera; this
+# fact only supplies the default when that key is unset.
+Facter.add(:service_manager) do
+  setcode do
+    is_zpinit =
+      File.exist?('/usr/local/bin/zpinit') ||
+      File.socket?('/run/zpinit.sock') ||
+      (File.readable?('/proc/1/comm') && File.read('/proc/1/comm').strip == 'zpinit')
+    is_zpinit ? 'zpinit' : 'supervisor'
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,7 +28,7 @@ class supervisord::config inherits supervisord {
       ensure => directory,
       owner  => $supervisord::user,
       group  => $supervisord::group,
-      mode   => '0644'
+      mode   => '0755'
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,16 @@
 #
 # Configuration class for supervisor init and conf directories
 #
+# When the node's backend is 'zpinit' this is a no-op: there is no supervisord
+# daemon, so its config dirs, supervisord.conf and init script are not managed
+# (and reload is not notified -- which is what was driving supervisorctl on
+# zpinit nodes). The class is still declared so the anchor chain in init.pp
+# resolves. Backend is auto-detected (see init.pp $service_manager) and
+# overridable via sc::service_manager.
+#
 class supervisord::config inherits supervisord {
+
+  unless $supervisord::service_manager == 'zpinit' {
 
   if ($supervisord::manage_config) {
     file { $supervisord::config_include:
@@ -89,5 +98,7 @@ class supervisord::config inherits supervisord {
       content => template('supervisord/supervisord_main.erb'),
       order   => '03'
     }
+  }
+
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -181,6 +181,18 @@ class supervisord(
     $config_include_string = "${config_include}/*.conf"
   }
 
+  # Backend detection, computed once and consumed by program.pp / install.pp /
+  # service.pp via $supervisord::service_manager. sc::service_manager is an
+  # OPTIONAL explicit override; when it is unset the value falls back to the
+  # $service_manager fact the node reports ('zpinit' when zpinit is the node's
+  # PID-1 supervisor, else 'supervisor'). 'supervisor' is the final fallback if
+  # the fact is somehow absent (e.g. pluginsync hasn't delivered it yet).
+  $_detected_service_manager = $facts['service_manager'] ? {
+    'zpinit' => 'zpinit',
+    default  => 'supervisor',
+  }
+  $service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', $_detected_service_manager)
+
   create_resources('supervisord::eventlistener', $eventlisteners)
   create_resources('supervisord::fcgi_program', $fcgi_programs)
   create_resources('supervisord::group', $groups)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,10 +30,15 @@ class supervisord::install inherits supervisord {
     }
   }
   else {
+    if $::supervisord::package_provider == 'pip' and file('/usr/local/bin/supervisord') {
+      notify { 'g package install': loglevel => 'debug' }
+    } 
+  else {
     package { $supervisord::package_name:
       ensure          => $supervisord::package_ensure,
       provider        => $supervisord::package_provider,
       install_options => $supervisord::package_install_options,
+      }
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,6 +18,7 @@ class supervisord::install inherits supervisord {
       path        => ['/usr/bin','/bin', '/usr/local/bin'],
       command     => "pipx install ${supervisord::package_name}",
       unless      => 'which supervisorctl',
+      require     => Package['pipx'],
     }
     file { '/usr/local/bin/supervisord':
       ensure => link,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,14 @@ class supervisord::install inherits supervisord {
       unless      => 'which supervisorctl',
     }
   }
+  elsif $::supervisord::package_provider == 'pipx' {
+    exec { 'pipx-install-supervisor':
+      user        => root,
+      path        => ['/usr/bin','/bin', '/usr/local/bin'],
+      command     => "pipx install ${supervisord::package_name}",
+      unless      => 'which supervisorctl',
+    }
+  }
   else {
     package { $supervisord::package_name:
       ensure          => $supervisord::package_ensure,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,6 +19,14 @@ class supervisord::install inherits supervisord {
       command     => "pipx install ${supervisord::package_name}",
       unless      => 'which supervisorctl',
     }
+    file { '/usr/local/bin/supervisord':
+      ensure => link,
+      target => '/root/.local/bin/supervisord',
+    }
+    file { '/usr/local/bin/supervisorctl':
+      ensure => link,
+      target => '/root/.local/bin/supervisorctl',
+    }
   }
   else {
     package { $supervisord::package_name:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,13 +2,21 @@
 #
 # Installs supervisor package (defaults to using pip)
 #
-# When the node's backend is 'zpinit' this is a no-op: the supervisord daemon
-# is not installed (zpinit is PID 1). The class is still declared so the
+# On a zpinit node the supervisord daemon is not installed (zpinit is PID 1).
+# Instead we drop a supervisorctl -> zpctl compatibility symlink so any legacy
+# caller still invoking `supervisorctl` (scripts, third-party tooling, cron
+# jobs) transparently drives zpinit; zpctl implements the same verbs
+# (status/start/stop/restart/update). The class is always declared so the
 # anchor chain in init.pp resolves. Backend is auto-detected (see init.pp
 # $service_manager) and overridable via sc::service_manager.
 #
 class supervisord::install inherits supervisord {
-  unless $supervisord::service_manager == 'zpinit' {
+  if $supervisord::service_manager == 'zpinit' {
+    file { '/usr/local/bin/supervisorctl':
+      ensure => link,
+      target => '/usr/local/bin/zpctl',
+    }
+  } else {
     # Check if supervisord is already installed in the system (not in venv)
     # This prevents reinstallation via pip in new venv when old system Python installation exists
     exec { 'check-supervisord-installed':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,14 +2,13 @@
 #
 # Installs supervisor package (defaults to using pip)
 #
-# When sc::service_manager is 'zpinit' this is a no-op: the supervisord daemon
+# When the node's backend is 'zpinit' this is a no-op: the supervisord daemon
 # is not installed (zpinit is PID 1). The class is still declared so the
-# anchor chain in init.pp resolves.
+# anchor chain in init.pp resolves. Backend is auto-detected (see init.pp
+# $service_manager) and overridable via sc::service_manager.
 #
 class supervisord::install inherits supervisord {
-  $_service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', 'supervisor')
-
-  unless $_service_manager == 'zpinit' {
+  unless $supervisord::service_manager == 'zpinit' {
     # Check if supervisord is already installed in the system (not in venv)
     # This prevents reinstallation via pip in new venv when old system Python installation exists
     exec { 'check-supervisord-installed':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,53 +2,61 @@
 #
 # Installs supervisor package (defaults to using pip)
 #
+# When sc::service_manager is 'zpinit' this is a no-op: the supervisord daemon
+# is not installed (zpinit is PID 1). The class is still declared so the
+# anchor chain in init.pp resolves.
+#
 class supervisord::install inherits supervisord {
-  # Check if supervisord is already installed in the system (not in venv)
-  # This prevents reinstallation via pip in new venv when old system Python installation exists
-  exec { 'check-supervisord-installed':
-    command => 'which supervisorctl || which supervisord',
-    path    => ['/usr/bin', '/bin', '/usr/local/bin'],
-    returns => [0, 1],
-    onlyif  => 'test -z "$(which supervisorctl 2>/dev/null)" && test -z "$(which supervisord 2>/dev/null)"',
-  }
+  $_service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', 'supervisor')
 
-  if $::supervisord::pip_proxy and $::supervisord::package_provider == 'pip' {
-    exec { 'pip-install-supervisor':
-      user        => root,
-      path        => ['/usr/bin','/bin'],
-      environment => [ "http_proxy=${supervisord::pip_proxy}", "https_proxy=${supervisord::pip_proxy}" ],
-      command     => "pip install ${supervisord::package_name}",
-      unless      => 'which supervisorctl',
+  unless $_service_manager == 'zpinit' {
+    # Check if supervisord is already installed in the system (not in venv)
+    # This prevents reinstallation via pip in new venv when old system Python installation exists
+    exec { 'check-supervisord-installed':
+      command => 'which supervisorctl || which supervisord',
+      path    => ['/usr/bin', '/bin', '/usr/local/bin'],
+      returns => [0, 1],
+      onlyif  => 'test -z "$(which supervisorctl 2>/dev/null)" && test -z "$(which supervisord 2>/dev/null)"',
     }
-  }
-  elsif $::supervisord::package_provider == 'pipx' {
-    exec { 'pipx-install-supervisor':
-      user        => root,
-      path        => ['/usr/bin','/bin', '/usr/local/bin'],
-      command     => "pipx install ${supervisord::package_name}",
-      unless      => 'which supervisorctl',
-      require     => Package['pipx'],
+
+    if $::supervisord::pip_proxy and $::supervisord::package_provider == 'pip' {
+      exec { 'pip-install-supervisor':
+        user        => root,
+        path        => ['/usr/bin','/bin'],
+        environment => [ "http_proxy=${supervisord::pip_proxy}", "https_proxy=${supervisord::pip_proxy}" ],
+        command     => "pip install ${supervisord::package_name}",
+        unless      => 'which supervisorctl',
+      }
     }
-    file { '/usr/local/bin/supervisord':
-      ensure => link,
-      target => '/root/.local/bin/supervisord',
+    elsif $::supervisord::package_provider == 'pipx' {
+      exec { 'pipx-install-supervisor':
+        user        => root,
+        path        => ['/usr/bin','/bin', '/usr/local/bin'],
+        command     => "pipx install ${supervisord::package_name}",
+        unless      => 'which supervisorctl',
+        require     => Package['pipx'],
+      }
+      file { '/usr/local/bin/supervisord':
+        ensure => link,
+        target => '/root/.local/bin/supervisord',
+      }
+      file { '/usr/local/bin/supervisorctl':
+        ensure => link,
+        target => '/root/.local/bin/supervisorctl',
+      }
     }
-    file { '/usr/local/bin/supervisorctl':
-      ensure => link,
-      target => '/root/.local/bin/supervisorctl',
-    }
-  }
-  else {
-    if $::supervisord::package_provider == 'pip' {
-      # Check if supervisord is already available in system PATH
-      # This prevents reinstallation via pip in new venv when old system Python installation exists
-      notify { 'supervisord already installed in system via pip, skipping installation': loglevel => 'debug' }
-    } 
     else {
-      package { $supervisord::package_name:
-        ensure          => $supervisord::package_ensure,
-        provider        => $supervisord::package_provider,
-        install_options => $supervisord::package_install_options,
+      if $::supervisord::package_provider == 'pip' {
+        # Check if supervisord is already available in system PATH
+        # This prevents reinstallation via pip in new venv when old system Python installation exists
+        notify { 'supervisord already installed in system via pip, skipping installation': loglevel => 'debug' }
+      }
+      else {
+        package { $supervisord::package_name:
+          ensure          => $supervisord::package_ensure,
+          provider        => $supervisord::package_provider,
+          install_options => $supervisord::package_install_options,
+        }
       }
     }
   }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -148,16 +148,11 @@ define supervisord::program(
       'priority'            => $priority,
       'ensure_process'      => $ensure_process,
     }.filter |$k, $v| { $v =~ NotUndef }
+    # zpinit::service writes the TOML and (when it declares no Service of its
+    # own) notifies zpinit::reload to run `zpctl update`, so a new/changed
+    # program is loaded into the running set without a backend-specific step
+    # here. Loading is owned by the zpinit module, not this dispatch shim.
     zpinit::service { $name: * => $_zpinit_params }
-
-    # Load the new/changed TOML into the running set. Mirrors the supervisord
-    # branch's notify to supervisord::reload (which on zpinit runs `zpctl
-    # update`). Required so a program with no separate Service[name] still gets
-    # started during the run instead of waiting for the next zpinit restart.
-    # Refresh propagates from the TOML file inside zpinit::service.
-    if $_cfgreload {
-      Zpinit::Service[$name] ~> Class['supervisord::reload']
-    }
   } else {
     $conf = "${supervisord::config_include}/program_${name}.conf"
 

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -116,13 +116,14 @@ define supervisord::program(
     default => $cfgreload
   }
 
-  # Backend selection. When sc::service_manager is 'zpinit', emit a zpinit
+  # Backend selection. When the node's backend is 'zpinit', emit a zpinit
   # service TOML instead of supervisord config / supervisorctl resources. The
   # Supervisord::Program[$title] resource still exists (this define), so existing
   # `before/require/notify => Supervisord::Program[X]` references keep resolving
   # on both backends -- no data rewrite needed. This is a transitional shim while
-  # the fleet migrates off supervisord.
-  $_service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', 'supervisor')
+  # the fleet migrates off supervisord. The backend is auto-detected (see
+  # supervisord/init.pp $service_manager) and overridable via sc::service_manager.
+  $_service_manager = $supervisord::service_manager
 
   if $_service_manager == 'zpinit' {
     # zpinit::service accepts supervisord parameter names; drop undef so strict

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -165,7 +165,12 @@ define supervisord::program(
       }
     }
 
-    if ($numprocs != 1 ) {
+    # supervisorctl target. A program is a homogeneous process group (members
+    # named "<name>:<process_name>") whenever numprocs > 1 OR process_name
+    # contains %(process_num) -- the latter can happen at numprocs == 1 via an
+    # explicit process_name, in which case the bare name is not addressable and
+    # supervisorctl reports "no such process". Use the ":*" group form for both.
+    if $numprocs != 1 or ($process_name and $process_name =~ /%\(process_num\)/) {
       $pname = "${name}:*"
     }
     else {

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -116,48 +116,82 @@ define supervisord::program(
     default => $cfgreload
   }
 
-  $conf = "${supervisord::config_include}/program_${name}.conf"
+  # Backend selection. When sc::service_manager is 'zpinit', emit a zpinit
+  # service TOML instead of supervisord config / supervisorctl resources. The
+  # Supervisord::Program[$title] resource still exists (this define), so existing
+  # `before/require/notify => Supervisord::Program[X]` references keep resolving
+  # on both backends -- no data rewrite needed. This is a transitional shim while
+  # the fleet migrates off supervisord.
+  $_service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', 'supervisor')
 
-  file { $conf:
-    ensure  => $ensure,
-    owner   => 'root',
-    mode    => $config_file_mode,
-    content => template('supervisord/conf/program.erb'),
-  }
+  if $_service_manager == 'zpinit' {
+    # zpinit::service accepts supervisord parameter names; drop undef so strict
+    # zpinit::service params (e.g. priority Integer[0,9999] default 50) fall back
+    # to their defaults. stdout/stderr logfile + redirect_stderr are
+    # intentionally NOT passed: their supervisord defaults are relative filenames
+    # that would become a bogus zpinit [log] path, and zpinit should inherit the
+    # container's stdout/stderr by default.
+    $_zpinit_params = {
+      'command'             => $command,
+      'ensure'              => $ensure,
+      'autostart'           => $autostart,
+      'autorestart'         => $autorestart,
+      'user'                => $user,
+      'numprocs'            => $numprocs,
+      'stopsignal'          => $stopsignal,
+      'stopwaitsecs'        => $stopwaitsecs,
+      'directory'           => $directory,
+      'environment'         => $environment,
+      'program_environment' => $program_environment,
+      'env_var'             => $env_var,
+      'priority'            => $priority,
+      'ensure_process'      => $ensure_process,
+    }.filter |$k, $v| { $v =~ NotUndef }
+    zpinit::service { $name: * => $_zpinit_params }
+  } else {
+    $conf = "${supervisord::config_include}/program_${name}.conf"
 
-  if $_cfgreload {
-    File[$conf] {
-      notify => Class['supervisord::reload'],
+    file { $conf:
+      ensure  => $ensure,
+      owner   => 'root',
+      mode    => $config_file_mode,
+      content => template('supervisord/conf/program.erb'),
     }
-  }
 
-  if ($numprocs != 1 ) {
-    $pname = "${name}:*"
-  }
-  else {
-    $pname = $name
-  }
-
-  case $ensure_process {
-    'stopped': {
-      supervisord::supervisorctl { "stop_${name}":
-        command => 'stop',
-        process => $pname
+    if $_cfgreload {
+      File[$conf] {
+        notify => Class['supervisord::reload'],
       }
     }
-    'removed': {
-      supervisord::supervisorctl { "remove_${name}":
-        command => 'remove',
-        process => $pname
-      }
+
+    if ($numprocs != 1 ) {
+      $pname = "${name}:*"
     }
-    'running': {
-      supervisord::supervisorctl { "start_${name}":
-        command => 'start',
-        process => $pname,
-        unless  => 'running'
-      }
+    else {
+      $pname = $name
     }
-    default: { }
+
+    case $ensure_process {
+      'stopped': {
+        supervisord::supervisorctl { "stop_${name}":
+          command => 'stop',
+          process => $pname
+        }
+      }
+      'removed': {
+        supervisord::supervisorctl { "remove_${name}":
+          command => 'remove',
+          process => $pname
+        }
+      }
+      'running': {
+        supervisord::supervisorctl { "start_${name}":
+          command => 'start',
+          process => $pname,
+          unless  => 'running'
+        }
+      }
+      default: { }
+    }
   }
 }

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -149,6 +149,15 @@ define supervisord::program(
       'ensure_process'      => $ensure_process,
     }.filter |$k, $v| { $v =~ NotUndef }
     zpinit::service { $name: * => $_zpinit_params }
+
+    # Load the new/changed TOML into the running set. Mirrors the supervisord
+    # branch's notify to supervisord::reload (which on zpinit runs `zpctl
+    # update`). Required so a program with no separate Service[name] still gets
+    # started during the run instead of waiting for the next zpinit restart.
+    # Refresh propagates from the TOML file inside zpinit::service.
+    if $_cfgreload {
+      Zpinit::Service[$name] ~> Class['supervisord::reload']
+    }
   } else {
     $conf = "${supervisord::config_include}/program_${name}.conf"
 

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -3,19 +3,17 @@
 # Class to reread and update supervisord with supervisorctl
 #
 class supervisord::reload inherits supervisord {
-  if $::supervisord::service_manage {
-    $supervisorctl = $::supervisord::executable_ctl
+  $supervisorctl = $::supervisord::executable_ctl
 
-    exec { 'supervisorctl_reread':
-      command     => "${supervisorctl} reread",
-      refreshonly => true,
-      require     => Service[$::supervisord::service_name],
-    }
-    exec { 'supervisorctl_update':
-      command     => "${supervisorctl} update",
-      refreshonly => true,
-      require     => Service[$::supervisord::service_name],
-    }
+  exec { 'supervisorctl_reread':
+    command     => "${supervisorctl} reread",
+    refreshonly => true,
+    require     => Service[$::supervisord::service_name],
+  }
+  exec { 'supervisorctl_update':
+    command     => "${supervisorctl} update",
+    refreshonly => true,
+    require     => Service[$::supervisord::service_name],
   }
 }
 

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -8,12 +8,10 @@ class supervisord::reload inherits supervisord {
   exec { 'supervisorctl_reread':
     command     => "${supervisorctl} reread",
     refreshonly => true,
-    require     => Service[$::supervisord::service_name],
   }
   exec { 'supervisorctl_update':
     command     => "${supervisorctl} update",
     refreshonly => true,
-    require     => Service[$::supervisord::service_name],
   }
 }
 

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -2,16 +2,24 @@
 #
 # Class to reread and update supervisord with supervisorctl
 #
+# When the node's backend is 'zpinit' this is a no-op: there is no supervisord
+# daemon and no supervisorctl to call. The class is still declared (and is a
+# harmless refresh target for config.pp) so existing notify/anchor references
+# resolve. Backend is auto-detected (see init.pp $service_manager) and
+# overridable via sc::service_manager.
+#
 class supervisord::reload inherits supervisord {
-  $supervisorctl = $::supervisord::executable_ctl
+  unless $supervisord::service_manager == 'zpinit' {
+    $supervisorctl = $::supervisord::executable_ctl
 
-  exec { 'supervisorctl_reread':
-    command     => "${supervisorctl} reread",
-    refreshonly => true,
-  }
-  exec { 'supervisorctl_update':
-    command     => "${supervisorctl} update",
-    refreshonly => true,
+    exec { 'supervisorctl_reread':
+      command     => "${supervisorctl} reread",
+      refreshonly => true,
+    }
+    exec { 'supervisorctl_update':
+      command     => "${supervisorctl} update",
+      refreshonly => true,
+    }
   }
 }
 

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -1,28 +1,17 @@
 # Class: supervisord::reload
 #
-# Loads added/changed program definitions into the running supervisor. Backend
-# is auto-detected (see init.pp $service_manager) and overridable via
+# Class to reread and update supervisord with supervisorctl
+#
+# When the node's backend is 'zpinit' this is a no-op: there is no supervisord
+# daemon and no supervisorctl to call, and loading TOMLs into the running set is
+# owned by the zpinit module (zpinit::service notifies zpinit::reload, which
+# runs `zpctl update`). The class is still declared (and is a harmless refresh
+# target for config.pp) so existing notify/anchor references resolve. Backend is
+# auto-detected (see init.pp $service_manager) and overridable via
 # sc::service_manager.
 #
-# On supervisord this runs `supervisorctl reread && update`. On zpinit it runs
-# the equivalent `zpctl update` (global config reload: starts added services,
-# stops removed, restarts changed -- see zpinit cmdUpdate). This matters because
-# zpinit does NOT pick up newly written service TOMLs on its own during a Puppet
-# run, so a program declared via supervisord::program that has no separate
-# Service[name] (e.g. cron, gitlab-runner, rundeck-node-consul-*) would
-# otherwise sit on disk unloaded until the next zpinit restart. program.pp
-# notifies this class when a program's config (conf or TOML) changes, on both
-# backends. Refreshonly + idempotent, so it is safe alongside the per-service
-# reload the zpinit Service provider already does for managed services.
-#
 class supervisord::reload inherits supervisord {
-  if $supervisord::service_manager == 'zpinit' {
-    exec { 'zpctl_update':
-      command     => 'zpctl update',
-      path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
-      refreshonly => true,
-    }
-  } else {
+  unless $supervisord::service_manager == 'zpinit' {
     $supervisorctl = $::supervisord::executable_ctl
 
     exec { 'supervisorctl_reread':

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -1,15 +1,28 @@
 # Class: supervisord::reload
 #
-# Class to reread and update supervisord with supervisorctl
+# Loads added/changed program definitions into the running supervisor. Backend
+# is auto-detected (see init.pp $service_manager) and overridable via
+# sc::service_manager.
 #
-# When the node's backend is 'zpinit' this is a no-op: there is no supervisord
-# daemon and no supervisorctl to call. The class is still declared (and is a
-# harmless refresh target for config.pp) so existing notify/anchor references
-# resolve. Backend is auto-detected (see init.pp $service_manager) and
-# overridable via sc::service_manager.
+# On supervisord this runs `supervisorctl reread && update`. On zpinit it runs
+# the equivalent `zpctl update` (global config reload: starts added services,
+# stops removed, restarts changed -- see zpinit cmdUpdate). This matters because
+# zpinit does NOT pick up newly written service TOMLs on its own during a Puppet
+# run, so a program declared via supervisord::program that has no separate
+# Service[name] (e.g. cron, gitlab-runner, rundeck-node-consul-*) would
+# otherwise sit on disk unloaded until the next zpinit restart. program.pp
+# notifies this class when a program's config (conf or TOML) changes, on both
+# backends. Refreshonly + idempotent, so it is safe alongside the per-service
+# reload the zpinit Service provider already does for managed services.
 #
 class supervisord::reload inherits supervisord {
-  unless $supervisord::service_manager == 'zpinit' {
+  if $supervisord::service_manager == 'zpinit' {
+    exec { 'zpctl_update':
+      command     => 'zpctl update',
+      path        => ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+      refreshonly => true,
+    }
+  } else {
     $supervisorctl = $::supervisord::executable_ctl
 
     exec { 'supervisorctl_reread':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,14 @@
 #
 # Class for the supervisord service
 #
+# When sc::service_manager is 'zpinit' this is a no-op: the supervisord daemon
+# service is not managed (zpinit supervises processes instead). The class is
+# still declared so the anchor chain in init.pp resolves.
+#
 class supervisord::service inherits supervisord  {
-  if $::supervisord::service_manage {
+  $_service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', 'supervisor')
+
+  if $::supervisord::service_manage and $_service_manager != 'zpinit' {
     if $::supervisord::init_type == 'systemd' {
       exec { 'refresh_supervisord_unit':
         command     => '/usr/bin/env systemctl daemon-reload',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,14 +2,14 @@
 #
 # Class for the supervisord service
 #
-# When sc::service_manager is 'zpinit' this is a no-op: the supervisord daemon
+# When the node's backend is 'zpinit' this is a no-op: the supervisord daemon
 # service is not managed (zpinit supervises processes instead). The class is
-# still declared so the anchor chain in init.pp resolves.
+# still declared so the anchor chain in init.pp resolves. Backend is
+# auto-detected (see init.pp $service_manager) and overridable via
+# sc::service_manager.
 #
 class supervisord::service inherits supervisord  {
-  $_service_manager = lookup('sc::service_manager', Enum['supervisor', 'zpinit'], 'first', 'supervisor')
-
-  if $::supervisord::service_manage and $_service_manager != 'zpinit' {
+  if $::supervisord::service_manage and $supervisord::service_manager != 'zpinit' {
     if $::supervisord::init_type == 'systemd' {
       exec { 'refresh_supervisord_unit':
         command     => '/usr/bin/env systemctl daemon-reload',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajcrowe-supervisord",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": "Alex Crowe",
   "license": "MIT",
   "summary": "Module supervisord class and functions",


### PR DESCRIPTION
This fixes #128. Changes to config or `supervisord::program` resources should always be applied, regardless of how the service is managed.