### PR TITLE
Allow current versions of stdlib (8.1.0) and concat (7.1.1) to be used

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.4.0 <5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0 <3.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.4.0 <9.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0 <8.0.0" }
   ]
 }


### PR DESCRIPTION
With this change, the module no longer blocks us from using up-to-date versions of these two central modules.

If you want to work with this PR in your `Puppetfile`, use `:git => 'https://github.com/mpdude/puppet-supervisord.git', :ref => 'update-stdlib-and-concat'`. 


